### PR TITLE
[conan-v2-ready] Do not raise ConanException for missing config.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ conan migrate:convert-txt conanfile.txt > conanfile.py
 For a list of references, returns a list of which have their latest revision present in the given remote,
 and whether it provides any binaries.
 
+
+```
+conan cci:list-v2-ready -r conancenter -f json conan-center-index/recipes > list-v2-ready.json
+```
+
 ### Testing
 
 To validate a new extension, it's possible to write a test that exercises its usage.

--- a/extensions/commands/cci/cmd_list_v2_ready.py
+++ b/extensions/commands/cci/cmd_list_v2_ready.py
@@ -13,6 +13,11 @@ def output_json(results):
     print(json.dumps(results, indent=2))
 
 
+def output_file_json(file_path, results):
+    with open(file_path, 'w') as f:
+        json.dump(results, f)
+
+
 @conan_command(group="Conan Center Index", formatters={"json": output_json})
 def list_v2_ready(conan_api: conan.api.conan_api.ConanAPI, parser, *args):
     """
@@ -22,6 +27,7 @@ def list_v2_ready(conan_api: conan.api.conan_api.ConanAPI, parser, *args):
     parser.add_argument('path', help="Path to global recipes folder")
     parser.add_argument('-r', '--remote', action=OnceArgument, help="Remote to query against")
     parser.add_argument('-p', '--profiles', action='append', default=list(), help="List of profiles to run graph info with if --skip-binaries is false")
+    parser.add_argument('-f', '--output-file', action=OnceArgument, help="A JSON file path to store the output")
     parser.add_argument('--skip-binaries', action='store_true', default=False, help="Skip binary checking for packages")
     args = parser.parse_args(*args)
 
@@ -113,4 +119,8 @@ def list_v2_ready(conan_api: conan.api.conan_api.ConanAPI, parser, *args):
                                 out.error(f"Error with graph info {ref}: {str(e)}")
                 except Exception as e:
                     out.error(f"Unexpected error for {ref}: {e}")
+
+    if args.output_file:
+        output_file_json(args.file_output, global_results)
+
     return global_results

--- a/extensions/commands/cci/cmd_list_v2_ready.py
+++ b/extensions/commands/cci/cmd_list_v2_ready.py
@@ -13,11 +13,6 @@ def output_json(results):
     print(json.dumps(results, indent=2))
 
 
-def output_file_json(file_path, results):
-    with open(file_path, 'w') as f:
-        json.dump(results, f)
-
-
 @conan_command(group="Conan Center Index", formatters={"json": output_json})
 def list_v2_ready(conan_api: conan.api.conan_api.ConanAPI, parser, *args):
     """
@@ -27,7 +22,6 @@ def list_v2_ready(conan_api: conan.api.conan_api.ConanAPI, parser, *args):
     parser.add_argument('path', help="Path to global recipes folder")
     parser.add_argument('-r', '--remote', action=OnceArgument, help="Remote to query against")
     parser.add_argument('-p', '--profiles', action='append', default=list(), help="List of profiles to run graph info with if --skip-binaries is false")
-    parser.add_argument('-f', '--output-file', action=OnceArgument, help="A JSON file path to store the output")
     parser.add_argument('--skip-binaries', action='store_true', default=False, help="Skip binary checking for packages")
     args = parser.parse_args(*args)
 
@@ -119,8 +113,4 @@ def list_v2_ready(conan_api: conan.api.conan_api.ConanAPI, parser, *args):
                                 out.error(f"Error with graph info {ref}: {str(e)}")
                 except Exception as e:
                     out.error(f"Unexpected error for {ref}: {e}")
-
-    if args.output_file:
-        output_file_json(args.file_output, global_results)
-
     return global_results

--- a/extensions/commands/cci/cmd_list_v2_ready.py
+++ b/extensions/commands/cci/cmd_list_v2_ready.py
@@ -39,7 +39,8 @@ def list_v2_ready(conan_api: conan.api.conan_api.ConanAPI, parser, *args):
         recipe_folder = os.path.join("recipes", recipe_name)
         config_file = os.path.join(recipe_folder, "config.yml")
         if not os.path.exists(config_file):
-            raise ConanException(f"The file {config_file} does not exist")
+            out.error(f"The file {config_file} does not exist")
+            continue
 
         with open(config_file, "r") as file:
             config = yaml.safe_load(file)


### PR DESCRIPTION
- Add command line example on README
- ConanCenterIndex has projects missing `config.yml` which cause break exit when using the custom commands. Better ignore them and mark as error message instead.
- ~Add an argument for an output file, because on regular terminal is easy by using `>` to redirect an output to file, but to run this command in Jenkins as part of a commands wrapper, it will be a mess.~

Related to #8 