### PR TITLE
Artifactory commands layer POC

### DIFF
--- a/.github/workflows/test_conan_extensions.yml
+++ b/.github/workflows/test_conan_extensions.yml
@@ -3,6 +3,11 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   conan_stable_linux:
     runs-on: ubuntu-20.04
+    env:
+      CONAN_LOGIN_USERNAME_EXTENSIONS_PROD: ${{ secrets.CONAN_USER }}
+      CONAN_PASSWORD_EXTENSIONS_PROD: ${{ secrets.CONAN_PASSWORD }}
+      CONAN_LOGIN_USERNAME_EXTENSIONS_STG: ${{ secrets.CONAN_USER }}
+      CONAN_PASSWORD_EXTENSIONS_STG: ${{ secrets.CONAN_PASSWORD }}
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.DS_Store

--- a/extensions/commands/art/cmd_build_info.py
+++ b/extensions/commands/art/cmd_build_info.py
@@ -1,0 +1,180 @@
+import datetime
+import json
+import os
+from pathlib import Path
+import re
+import hashlib
+
+import requests
+
+from conan.api.conan_api import ConanAPI
+from conan.api.output import cli_out_write
+from conan.cli.command import conan_command, conan_subcommand
+from conan.errors import ConanException
+from conans.model.recipe_ref import RecipeReference
+from conan import conan_version
+
+
+def response_to_str(response):
+    content = response.content
+    try:
+        # A bytes message, decode it as str
+        if isinstance(content, bytes):
+            content = content.decode()
+
+        content_type = response.headers.get("content-type")
+
+        if content_type == "application/json":
+            # Errors from Artifactory looks like:
+            #  {"errors" : [ {"status" : 400, "message" : "Bla bla bla"}]}
+            try:
+                data = json.loads(content)["errors"][0]
+                content = "{}: {}".format(data["status"], data["message"])
+            except Exception:
+                pass
+        elif "text/html" in content_type:
+            content = "{}: {}".format(response.status_code, response.reason)
+
+        return content
+
+    except Exception:
+        return response.content
+
+
+def get_export_path_from_rrev(rrev):
+    ref = RecipeReference.loads(rrev)
+    return f"_/{ref.name}/{ref.version}/_/{ref.revision}/export"
+
+
+def get_rrev_artifacts(node):
+    artifacts = []
+    recipe_folder = node.get("recipe_folder")
+    dl_folder = Path(recipe_folder).parents[0] / "d"
+    # TODO: throw error if d is empty? Force that the artifacts where uploaded before getting the BuildInfo?
+    for file_path in dl_folder.glob("*"):
+        if file_path.is_file():
+            with open(file_path, "rb") as file:
+                file_name = file_path.name
+                read_file = file.read()
+                md5 = hashlib.md5(read_file).hexdigest()
+                sha1 = hashlib.sha1(read_file).hexdigest()
+                sha256 = hashlib.sha256(read_file).hexdigest()
+                artifacts.append({"name": file_name,
+                                  "type": os.path.splitext(file_name)[1].lstrip('.'),
+                                  "path": f'{get_export_path_from_rrev(node.get("ref"))}/{file_name}',
+                                  "sha256": sha256,
+                                  "sha1": sha1,
+                                  "md5": md5})
+    return artifacts
+
+
+def get_modules(json):
+    ret = []
+    try:
+        nodes = json["graph"]["nodes"]
+    except KeyError:
+        raise ConanException("JSON does not contain graph information")
+
+    for node in nodes:
+        ref = node.get("ref")
+        if ref and ref != "conanfile":
+            module = {
+                "type": "conan",
+                "id": str(ref),
+                "artifacts": get_rrev_artifacts(node)
+            }
+            ret.append(module)
+    return ret
+
+
+def create_build_info(data, build_name, build_number):
+
+    properties = {
+        "name": build_name,
+        "number": build_number
+    }
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    local_tz_offset = now.astimezone().strftime('%z')
+    formatted_time = now.strftime(
+        '%Y-%m-%dT%H:%M:%S.%f')[:-3] + local_tz_offset
+
+    if local_tz_offset == "+0000":
+        formatted_time = formatted_time[:-5] + "Z"
+
+    # from here: https://github.com/jfrog/build-info-go/blob/9b6f2ec13eedc41ad0f66882e630c2882f90cc76/buildinfo-schema.json#L63
+    if not re.match(r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}(Z|[+-]\d{4})$', formatted_time):
+        raise ValueError("Time format does not match BuildInfo required format.")
+
+    ret = {"version": "1.0.1",
+           "name": properties.get("name"),
+           "number": properties.get("number"),
+           "agent": {},
+           "started": formatted_time,
+           "buildAgent": {"name": "conan", "version": f"{str(conan_version)}"},
+           "modules": get_modules(data)}
+
+    return json.dumps(ret, indent=4)
+
+
+@conan_command(group="Custom commands")
+def build_info(conan_api: ConanAPI, parser, *args):
+    """
+    Manages JFROG BuildInfo
+    """
+
+
+@conan_subcommand()
+def build_info_create(conan_api: ConanAPI, parser, subparser, *args):
+    """
+    Creates BuildInfo from a Conan graph json from a conan install or create.
+    """
+
+    subparser.add_argument("json", help="Conan generated JSON output file.")
+    subparser.add_argument("name", help="Build name property for BuildInfo.")
+    subparser.add_argument("number", help="Build number property for BuildInfo.")
+    args = parser.parse_args(*args)
+
+    with open(args.json, 'r') as f:
+        data = json.load(f)
+
+    info = create_build_info(data, args.name, args.number)
+
+    cli_out_write(info)
+
+
+@conan_subcommand()
+def build_info_upload(conan_api: ConanAPI, parser, subparser, *args):
+    """
+    Uploads BuildInfo json to repository.
+    """
+
+    subparser.add_argument("build_info", help="BuildInfo json file.")
+    subparser.add_argument(
+        "url", help="Artifactory url, like: https://<address>/artifactory")
+    subparser.add_argument("--user", help="user name for the repository")
+    subparser.add_argument("--password", help="password for the user name")
+    subparser.add_argument("--apikey", help="apikey for the repository")
+    args = parser.parse_args(*args)
+
+    url = args.url
+    user = args.user
+    password = args.password
+    apikey = args.apikey
+
+    with open(args.build_info) as json_data:
+        request_url = f"{url.rstrip('/')}/api/build"
+        if user and password:
+            response = requests.put(request_url, headers={"Content-Type": "application/json"},
+                                    data=json_data, auth=(user, password))
+        elif apikey:
+            response = requests.put(request_url, headers={"Content-Type": "application/json",
+                                                          "X-JFrog-Art-Api": apikey},
+                                    data=json_data)
+        else:
+            response = requests.put(request_url)
+
+        if response.status_code == 401:
+            raise Exception(response_to_str(response))
+        elif response.status_code != 204:
+            raise Exception(response_to_str(response))

--- a/extensions/commands/art/cmd_property.py
+++ b/extensions/commands/art/cmd_property.py
@@ -1,0 +1,172 @@
+import json
+from pathlib import Path
+
+import requests
+
+from conan.api.conan_api import ConanAPI
+from conan.cli.command import conan_command, conan_subcommand
+from conans.model.recipe_ref import RecipeReference
+from conans.model.package_ref import PkgReference
+from conan.errors import ConanException
+
+
+def response_to_str(response):
+    content = response.content
+    try:
+        # A bytes message, decode it as str
+        if isinstance(content, bytes):
+            content = content.decode()
+
+        content_type = response.headers.get("content-type")
+
+        if content_type == "application/json":
+            # Errors from Artifactory looks like:
+            #  {"errors" : [ {"status" : 400, "message" : "Bla bla bla"}]}
+            try:
+                data = json.loads(content)["errors"][0]
+                content = "{}: {}".format(data["status"], data["message"])
+            except Exception:
+                pass
+        elif "text/html" in content_type:
+            content = "{}: {}".format(response.status_code, response.reason)
+
+        return content
+
+    except Exception:
+        return response.content
+
+
+def get_path_from_ref(ref):
+    try:
+        package_ref = PkgReference.loads(ref)
+        recipe_ref = package_ref.ref
+    except ConanException:
+        recipe_ref = RecipeReference.loads(ref)
+        package_ref = None
+
+    rrev_path = f"/_/{recipe_ref.revision}" if recipe_ref.revision else ""
+    pkgid_path = f"/package/{package_ref.package_id}" if package_ref and package_ref.package_id else ""
+    prev_path = f"/{package_ref.revision}" if package_ref and package_ref.revision else ""
+    return f"_/{recipe_ref.name}/{recipe_ref.version}{rrev_path}{pkgid_path}{prev_path}"
+
+
+def api_request(type, request_url, user=None, password=None, apikey=None, json_data=None):
+
+    headers = {}
+    if json_data:
+        headers.update({"Content-Type": "application/json"})
+    if apikey:
+        headers.update({"X-JFrog-Art-Api": apikey})
+
+    requests_method = getattr(requests, type)
+    if user and password:
+        response = requests_method(request_url, auth=(
+            user, password), data=json_data, headers=headers)
+    elif apikey:
+        response = requests_method(
+            request_url, data=json_data, headers=headers)
+    else:
+        response = requests_method(request_url)
+
+    if response.status_code == 401:
+        raise Exception(response_to_str(response))
+    elif response.status_code not in [200, 204]:
+        raise Exception(response_to_str(response))
+
+    return response_to_str(response)
+
+
+def add_default_arguments(subparser):
+    subparser.add_argument("url", help="Artifactory url, like: https://<address>/artifactory")
+    subparser.add_argument("repository", help="Artifactory repository.")
+    subparser.add_argument("reference", help="Conan reference.")
+    subparser.add_argument("--user", help="user name for the repository")
+    subparser.add_argument("--password", help="password for the user name")
+    subparser.add_argument("--apikey", help="apikey for the repository")
+    subparser.add_argument("--property", action='append',
+                           help='Property to add, like --property="build.name=buildname" --property="build.number=1"')
+
+    return subparser
+
+
+@conan_command(group="Custom commands")
+def property(conan_api: ConanAPI, parser, *args):
+    """
+    Sets artifacts properties in Artifactory.
+    """
+
+
+@conan_subcommand()
+def property_add(conan_api: ConanAPI, parser, subparser, *args):
+    """
+    Set properties for artifacts under a Conan reference recursively.
+    """
+
+    add_default_arguments(subparser)
+
+    args = parser.parse_args(*args)
+
+    # TODO: do we want to add properties to folders? it's slower but when
+    # we set properties recursive the folders are also set, so setting also
+    # for folders for consistency and check what to do
+    list_folders = "1"
+
+    # get artifacts recursively from a starting path
+    root_path = get_path_from_ref(args.reference)
+
+    request_url = f"{args.url}/api/storage/{args.repository}/{root_path}?list&deep=1&listFolders={list_folders}"
+
+    data = json.loads(api_request("get", request_url,
+                      args.user, args.password, args.apikey))
+
+    # just consider those artifacts that have conan in the name
+    conan_artifacts = [artifact for artifact in data.get("files") if "conan" in artifact.get('uri')]
+
+    # get properties for all artifacts
+    for artifact in data.get("files"):
+        uri = artifact.get('uri')
+
+        request_url = f"{args.url}/api/storage/{args.repository}/{root_path}{uri}?properties"
+
+        artifact_properties = {}
+
+        try:
+            props_response = api_request(
+                "get", request_url, args.user, args.password, args.apikey)
+            artifact_properties = json.loads(props_response).get("properties")
+        except:
+            pass
+
+        for property in args.property:
+            key, val = property.split('=')[0], property.split('=')[1]
+            if artifact_properties.get(key) and val not in artifact_properties.get(key):
+                artifact_properties[key].append(val)
+            else:
+                artifact_properties[key] = val
+
+        if artifact_properties:
+            request_url = f"{args.url}/api/metadata/{args.repository}/{root_path}{uri}?&recursiveProperties=0"
+            api_request("patch", request_url, args.user, args.password,
+                        args.apikey, json_data=json.dumps({"props": artifact_properties}))
+
+
+@conan_subcommand()
+def property_set(conan_api: ConanAPI, parser, subparser, *args):
+    """
+    Set properties for artifacts under a Conan reference recursively.
+    """
+
+    add_default_arguments(subparser)
+
+    subparser.add_argument('--no-recursive', dest='recursive',
+                           action='store_false', help='Will not recursively set properties.')
+    args = parser.parse_args(*args)
+
+    recursive = "1" if args.recursive else "0"
+
+    json_data = json.dumps(
+        {"props": {prop.split('=')[0]: prop.split('=')[1] for prop in args.property}})
+
+    request_url = f"{args.url}/api/metadata/{args.repository}/{get_path_from_ref(args.reference)}?&recursiveProperties={recursive}"
+
+    api_request("patch", request_url, args.user, args.password, args.apikey, json_data=json_data)

--- a/tests/test_artifactory_commands.py
+++ b/tests/test_artifactory_commands.py
@@ -1,0 +1,45 @@
+import tempfile
+import os
+
+
+from tools import run
+
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def conan_test():
+    old_env = dict(os.environ)
+    env_vars = {"CONAN_HOME": tempfile.mkdtemp(suffix='conans')}
+    os.environ.update(env_vars)
+    current = tempfile.mkdtemp(suffix="conans")
+    cwd = os.getcwd()
+    os.chdir(current)
+
+    run("conan profile detect")
+    run("conan remote add extensions-prod https://conanv2beta.jfrog.io/artifactory/api/conan/extensions-prod")
+    run("conan remote add extensions-stg https://conanv2beta.jfrog.io/artifactory/api/conan/extensions-stg")
+
+    try:
+        yield
+    finally:
+        os.chdir(cwd)
+        os.environ.clear()
+        os.environ.update(old_env)
+
+
+def run(cmd):
+    ret = os.system(cmd)
+    if ret != 0:
+        raise Exception(f"Failed CMD: {cmd}")
+
+
+def test_build_info_create():
+    repo = os.path.join(os.path.dirname(__file__), "..")
+
+    run(f"conan config install {repo}")
+    run("conan new cmake_lib -d name=mypkg -d version=1.0 --force")
+    run("conan create . --format json > create.json")
+    run("conan upload mypkg/1.0 -c -r extensions-stg")
+    run("conan art:build-info create create.json mybuildname 1 > buildinfo.json")

--- a/tests/test_convert_txt.py
+++ b/tests/test_convert_txt.py
@@ -2,12 +2,15 @@ import tempfile
 import textwrap
 import os
 
+from tools import load, save, run
+
 import pytest
+
 
 @pytest.fixture(autouse=True)
 def conan_test():
     old_env = dict(os.environ)
-    env_vars = {"CONAN_HOME": tempfile.mkdtemp(suffix='conans')} 
+    env_vars = {"CONAN_HOME": tempfile.mkdtemp(suffix='conans')}
     os.environ.update(env_vars)
     current = tempfile.mkdtemp(suffix="conans")
     cwd = os.getcwd()
@@ -19,20 +22,6 @@ def conan_test():
         os.environ.clear()
         os.environ.update(old_env)
 
-
-def run(cmd):
-    ret = os.system(cmd)
-    if ret != 0:
-        raise Exception(f"Failed CMD: {cmd}")
-
-
-def save(f, content):
-    with open(f, "w") as f:
-        f.write(content)
-
-def load(f):
-    with open(f, "r") as f:
-        return f.read()
 
 def test_convert_txt():
     repo = os.path.join(os.path.dirname(__file__), "..")
@@ -83,6 +72,3 @@ def test_convert_txt():
 
         """)
     assert conanfile_py == expected
-
-
-    

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -1,0 +1,28 @@
+import subprocess
+
+
+def run(cmd, error=False):
+    process = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+    out, err = process.communicate()
+    out = out.decode("utf-8")
+    err = err.decode("utf-8")
+    ret = process.returncode
+
+    output = err + out
+    if ret != 0 and not error:
+        raise Exception("Failed cmd: {}\n{}".format(cmd, output))
+    if ret == 0 and error:
+        raise Exception(
+            "Cmd succeded (failure expected): {}\n{}".format(cmd, output))
+    return output
+
+
+def save(f, content):
+    with open(f, "w") as f:
+        f.write(content)
+
+
+def load(f):
+    with open(f, "r") as f:
+        return f.read()


### PR DESCRIPTION
This is just a very basic proof of concept around a command layer to:

- Create and upload BuildInfo to Artifactory. At the moment it's just a very basic implementation considering recipe artifacts only.
- Modify artifacts properties in Artifactory

This is also adding two repositories for testing so that we can do real functional tests with two remotes.