### PR TITLE
create bump_reqs command

### DIFF
--- a/extensions/commands/cmd_bump_reqs.py
+++ b/extensions/commands/cmd_bump_reqs.py
@@ -1,0 +1,55 @@
+import ast
+import os
+import sys
+
+from conan.api.conan_api import ConanAPI
+from conan.api.model import ListPattern
+from conan.api.output import ConanOutput
+from conan.cli.command import conan_command
+
+
+@conan_command(group="Extension")
+def bump_reqs(conan_api: ConanAPI, parser, *args):
+    """
+    command bumping all requirements of a recipe
+    """
+    parser.add_argument("recipe", help="Recipe for which the requirements will be bumped", default="conanfile.py")
+    parser.add_argument("--remote", "-r", help="Name of the remote providing new versions", default="*")
+    args = parser.parse_args(*args)
+    recipe_file = args.recipe
+
+    if not os.path.isfile(recipe_file):
+        ConanOutput().error(f"Recipe file {recipe_file} not found")
+        sys.exit(-1)
+
+    with open(recipe_file) as f:
+        recipe = f.read()
+        f.seek(0)
+        recipe_lines = f.readlines()
+
+    for node in ast.walk(ast.parse(recipe)):
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Attribute):
+                if node.func.attr in ["requires", "build_requires", "tool_requires"]:
+                    arg = node.args[0]
+                    if not isinstance(arg, ast.Constant):
+                        ConanOutput().warning(f"Unable to bump non constant requirement in {recipe_file}:{arg.lineno}")
+                        continue
+                    oldref = arg.value
+                    name = oldref.split("/")[0]
+                    try:
+                        refs = conan_api.list.select(ListPattern(name), remote=conan_api.remotes.list(args.remote)[0])
+                    except Exception as inst:
+                        ConanOutput().warning(f"Error bumping {oldref} in {recipe_file}:{arg.lineno}")
+                        ConanOutput().warning(inst)
+                        continue
+                    newref = list(refs.recipes.keys())[-1]
+                    if newref != oldref:
+                        line = arg.lineno - 1
+                        recipe_lines[line] = recipe_lines[line].replace(oldref, newref)
+                        ConanOutput().info(f"updating {oldref} to {newref} in {recipe_file}:{arg.lineno}")
+
+    with open(recipe_file, 'w') as f:
+        f.writelines(recipe_lines)
+
+    ConanOutput().success(f"Successfully bumped the requirements of recipe {recipe_file}")


### PR DESCRIPTION
This commands takes as argument the path to a recipe file, and bumps all the `requires`, `build_requires` and `tool_requires` to the latest version available of the required package on the remote.

usage example:
```
$ conan bump-reqs 5.x.x/conanfile.py
updating openssl/1.1.1t to openssl/3.1.0 in 5.x.x/conanfile.py:363
updating vulkan-loader/1.3.224.0 to vulkan-loader/1.3.239.0 in 5.x.x/conanfile.py:367
updating glib/2.75.3 to glib/2.76.1 in 5.x.x/conanfile.py:371
updating freetype/2.12.1 to freetype/2.13.0 in 5.x.x/conanfile.py:377
updating harfbuzz/5.3.1 to harfbuzz/6.0.0 in 5.x.x/conanfile.py:383
updating sqlite3/3.39.4 to sqlite3/3.41.1 in 5.x.x/conanfile.py:392
updating libmysqlclient/8.0.30 to libmysqlclient/8.0.31 in 5.x.x/conanfile.py:394
updating libpq/14.5 to libpq/14.7 in 5.x.x/conanfile.py:396
WARN: Error bumping krb5/1.18.3 in 5.x.x/conanfile.py:430
WARN: Recipe 'krb5' not found
updating at-spi2-core/2.46.0 to at-spi2-core/2.47.1 in 5.x.x/conanfile.py:432
updating moltenvk/1.1.10 to moltenvk/1.2.1 in 5.x.x/conanfile.py:369
updating libjpeg-turbo/2.1.4 to libjpeg-turbo/2.1.5 in 5.x.x/conanfile.py:386
```
It performs the update on the source recipe (not in cache), so that the user can check if something breaks.