### PR TITLE
[DRAFT] Add BuildInfo dependencies support

### DIFF
--- a/.conanignore
+++ b/.conanignore
@@ -8,3 +8,5 @@ LICENSE
 *.DS_Store*
 *.pytest_cache*
 tmp/*
+tmp2/*
+.idea/*

--- a/.gitignore
+++ b/.gitignore
@@ -129,4 +129,5 @@ dmypy.json
 .pyre/
 .DS_Store
 tests/credentials.py
-tmp/*
+tmp*/*
+.idea/*

--- a/extensions/commands/art/cmd_build_info.py
+++ b/extensions/commands/art/cmd_build_info.py
@@ -357,7 +357,7 @@ def build_info_promote(conan_api: ConanAPI, parser, subparser, *args):
     subparser.add_argument("source_repo", help="Source repo for promotion.")
     subparser.add_argument("target_repo", help="Target repo for promotion.")
 
-    subparser.add_argument("--dependencies", help="Whether to move/copy the build's dependencies. Default: false.",
+    subparser.add_argument("--dependencies", help="Whether to copy the build's dependencies or not. Default: false.",
                            action='store_true', default=False)
     subparser.add_argument("--comment", help="An optional comment describing the reason for promotion. Default: ''")
 
@@ -414,7 +414,7 @@ def build_info_delete(conan_api: ConanAPI, parser, subparser, *args):
     Removes builds stored in Artifactory. Useful for cleaning up old build info data.
     """
 
-    subparser.add_argument("build_name", help="BuildInfo name to promote.")
+    subparser.add_argument("build_name", help="BuildInfo name to delete.")
     subparser.add_argument("url", help="Artifactory url, like: https://<address>/artifactory")
 
     subparser.add_argument("--build-number", help="BuildInfo numbers to promote. You can add " \

--- a/extensions/commands/art/cmd_build_info.py
+++ b/extensions/commands/art/cmd_build_info.py
@@ -191,10 +191,14 @@ class BuildInfo:
                 for artifact in artifacts_names:
                     request_url = f"{self._url}/api/storage/{repository}/{remote_path}/{artifact}"
                     if not self._cached_artifact_info.get(request_url):
-                        response = api_request("get", request_url, self._user, self._password, self._apikey)
-                        response_data = json.loads(response)
-                        checksums = response_data.get("checksums")
-                        self._cached_artifact_info[request_url] = checksums
+                        checksums = None
+                        try:
+                            response = api_request("get", request_url, self._user, self._password, self._apikey)
+                            response_data = json.loads(response)
+                            checksums = response_data.get("checksums")
+                            self._cached_artifact_info[request_url] = checksums
+                        except Exception:
+                            pass
                     else:
                         checksums = self._cached_artifact_info.get(request_url)
 

--- a/tests/test_artifactory_commands.py
+++ b/tests/test_artifactory_commands.py
@@ -214,4 +214,9 @@ def test_fail_if_not_uploaded():
 
     out = run(f'conan art:build-info create create.json {build_name} {build_number}', error=True)
 
-    assert "Artifacts are missing in the cache" in out
+    assert "Missing information in the Conan local cache, please provide " \
+           "the --url and --repository arguments to retrieve the information from" in out
+
+    out = run(f'conan art:build-info create create.json {build_name} {build_number} --url={os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}" --repository=extensions-stg > {build_name}.json', error=True)
+
+    assert "There are no artifacts for the mypkg/1.0#" in out

--- a/tests/test_artifactory_commands.py
+++ b/tests/test_artifactory_commands.py
@@ -8,7 +8,7 @@ try:
     # extensions-stg and extensions-prod repos, define this dict of credentials
     # in credentials.py (the file is gitignored)
 
-    # environment = {
+    # creds_env = {
     #     "CONAN_LOGIN_USERNAME_EXTENSIONS_PROD": "......",
     #     "CONAN_PASSWORD_EXTENSIONS_PROD": "......",
     #     "CONAN_LOGIN_USERNAME_EXTENSIONS_STG": "......",
@@ -16,7 +16,7 @@ try:
     #     "ART_URL": "https://url/artifactory",
     # }
 
-    from credentials import environment
+    from credentials import creds_env
 except ImportError:
     environment = {}
 
@@ -28,7 +28,7 @@ def conan_test():
     old_env = dict(os.environ)
     env_vars = {"CONAN_HOME": tempfile.mkdtemp(suffix='conans')}
     os.environ.update(env_vars)
-    os.environ.update(environment)
+    os.environ.update(creds_env)
     current = tempfile.mkdtemp(suffix="conans")
     cwd = os.getcwd()
     os.chdir(current)
@@ -44,7 +44,7 @@ def conan_test():
         os.environ.update(old_env)
 
 
-def test_build_info_create():
+def test_build_info_create_no_deps():
     repo = os.path.join(os.path.dirname(__file__), "..")
 
     build_name = "mybuildinfo"
@@ -103,6 +103,91 @@ def test_build_info_create():
 
     # even deleting the builds, the folders will stay there, so manually cleaning
     run('conan remove mypkg* -c -r extensions-prod')
+
+
+def test_build_info_create_deps():
+    repo = os.path.join(os.path.dirname(__file__), "..")
+
+    build_name = "mybuildinfo"
+    build_number = "1"
+
+    #        +-------+
+    #        | libc  |
+    #        +-------+
+    #             |
+    #      +------+------+ 
+    #      |             |
+    #  +---+---+     +---+---+
+    #  | liba  |     | libb  |
+    #  +---+---+     +---+---+
+    #      |             |
+    #      +-------+-----+
+    #              |
+    #           +--+--+
+    #           |mypkg|
+    #           +-----+
+
+    run(f"conan config install {repo}")
+    run("conan new cmake_lib -d name=libc -d version=1.0 --force")
+    run("conan export .")
+    run("conan new cmake_lib -d name=liba -d version=1.0 -d requires=libc/1.0 --force")
+    run("conan export .")
+    run("conan new cmake_lib -d name=libb -d version=1.0 -d requires=libc/1.0 --force")
+    run("conan export .")
+    run("conan new cmake_lib -d name=mypkg -d version=1.0 -d requires=liba/1.0 -d requires=libb/1.0 --force")
+
+    run("conan create . --format json -tf='' -s build_type=Release --build='*' > create_release.json")
+    run("conan create . --format json -tf='' -s build_type=Debug --build='*' > create_debug.json")
+
+    for lib in ["liba", "libb", "libc", "mypkg"]:
+        run(f"conan remove '{lib}*' -c -r extensions-stg")
+        run(f"conan remove '{lib}*' -c -r extensions-prod")
+
+    for lib in ["liba", "libb", "libc", "mypkg"]:
+        run(f"conan upload '{lib}*' -c -r extensions-stg")
+
+    run(f'conan art:build-info create create_release.json {build_name}_release {build_number} > {build_name}_release.json')
+    run(f'conan art:build-info create create_debug.json {build_name}_debug {build_number} > {build_name}_debug.json')
+
+    run(f'conan art:property build-info-add {build_name}_release.json {os.getenv("ART_URL")} extensions-stg --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
+    run(f'conan art:property build-info-add {build_name}_debug.json {os.getenv("ART_URL")} extensions-stg --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
+
+    run(f'conan art:build-info upload {build_name}_release.json {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
+    run(f'conan art:build-info upload {build_name}_debug.json {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
+
+    # aggregate the release and debug build infos into an aggregated one
+    # we also have to set the properties so that the paths to the artifacts are linked
+    # with the build info in Artifactory
+    # run(f'conan art:build-info append {build_name}_aggregated {build_number} --build-info={build_name}_release.json --build-info={build_name}_debug.json > {build_name}_aggregated.json')
+    # run(f'conan art:build-info upload {build_name}_aggregated.json {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
+    # run(f'conan art:property build-info-add {build_name}_aggregated.json {os.getenv("ART_URL")} extensions-stg --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
+
+    # run(f'conan art:build-info get {build_name}_release {build_number} {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
+    # run(f'conan art:build-info get {build_name}_debug {build_number} {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
+    # run(f'conan art:build-info get {build_name}_aggregated {build_number} {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
+
+    # run(f'conan art:build-info promote {build_name}_aggregated {build_number} {os.getenv("ART_URL")} extensions-stg extensions-prod --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
+
+    # # The local clean is because later I'm going to do a conan install from prod repo 
+    # # and I want to make sure that the install succeeds because the package comes from 
+    # # the remote and not because it's already in the cache. 
+    # run('conan remove mypkg* -c')
+
+    # # we have to remove the package from the source repo because in the Conan promotion we copy
+    # # Conan promotions must always be copy, and the clean must be handled manually
+    # # otherwise you can end up deleting recipe artifacts that other packages use
+    # run('conan remove mypkg* -c -r extensions-stg')
+
+    # # check that we can install from the prod repo after the promotion
+    # run('conan install --requires=mypkg/1.0 -r extensions-prod -s build_type=Release')
+    # run('conan install --requires=mypkg/1.0 -r extensions-prod -s build_type=Debug')
+
+    # run(f'conan art:build-info delete {build_name}_release {os.getenv("ART_URL")} --build-number={build_number} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}" --delete-all --delete-artifacts')
+    # run(f'conan art:build-info delete {build_name}_debug {os.getenv("ART_URL")} --build-number={build_number} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}" --delete-all --delete-artifacts')
+    # run(f'conan art:build-info delete {build_name}_aggregated {os.getenv("ART_URL")} --build-number={build_number} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}" --delete-all --delete-artifacts')
+
+    # # even deleting the builds, the folders will stay there, so manually cleaning
+    # run('conan remove mypkg* -c -r extensions-prod')
 
 
 def test_fail_if_not_uploaded():

--- a/tests/test_artifactory_commands.py
+++ b/tests/test_artifactory_commands.py
@@ -18,7 +18,7 @@ try:
 
     from credentials import creds_env
 except ImportError:
-    environment = {}
+    creds_env = {}
 
 import pytest
 


### PR DESCRIPTION
Still a lot to refactor and clean, it's still a bit messy.

Found issues:

- Looks like BuildInfo promotion with dependencies does not work, it works ok for all artifacts declared in the modules as dependencies except for the case of the `conaninfo.txt` this happens because it appears two times as a dependency with the same hash, because the package id is the same for two different revisions. Looks like as the hash is the same and it appears multiple times Artifactory skips the copy the second time.
- Also the transitive dependencies problem is not handled yet, only direct dependencies are added