### PR TITLE
Ignore Artifactory tests if no credentials defined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,5 @@ dmypy.json
 .pyre/
 .DS_Store
 tests/credentials.py
-tmp/*
-tmp2/*
+tmp*/*
 .idea/*

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dmypy.json
 .DS_Store
 tests/credentials.py
 tmp/*
+tmp2/*
+.idea/*

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import os
+import pytest
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        if "requires_credentials" in item.keywords:
+            if (
+                not os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_PROD")
+                or not os.getenv("CONAN_PASSWORD_EXTENSIONS_PROD")
+                or not os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")
+                or not os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")
+                or not os.getenv("ART_URL")
+            ):
+                item.add_marker(pytest.mark.skip(reason="Missing required credentials environment variables"))
+                print(f"Skipping test {item.nodeid}. Missing required credentials environment variables.")

--- a/tests/test_artifactory_commands.py
+++ b/tests/test_artifactory_commands.py
@@ -44,6 +44,7 @@ def conan_test():
         os.environ.update(old_env)
 
 
+@pytest.mark.requires_credentials
 def test_build_info_create():
     repo = os.path.join(os.path.dirname(__file__), "..")
 


### PR DESCRIPTION
When a contributor opens a PR the secrets for the credentials are not defined in the fork making the PR's fail. Proposing to skip those tests when the credentials are not available.
If this approach works this PR should not fail.

Now the CI skips those tests:

```
tests/test_artifactory_commands.py::test_build_info_create SKIPPED (...) [ 25%]
tests/test_artifactory_commands.py::test_fail_if_not_uploaded PASSED     [ 50%]
tests/test_convert_txt.py::test_convert_txt PASSED                       [ 75%]
tests/test_export_all_versions.py::test_convert_txt PASSED               [100%]
```

Related to: https://github.com/conan-io/conan-extensions/pull/15#issuecomment-1502743655