### PR TITLE
Create Release Bundles via the new Artifactory API

### DIFF
--- a/extensions/commands/art/README.md
+++ b/extensions/commands/art/README.md
@@ -73,15 +73,15 @@ Using the generated JSON files you can create a BuildInfo JSON. You have to pass
 name and number and also the url and credentials for the Artifactory repository:
 
 ```
-conan art:build-info create create_release.json mybuildname_release 1 --url=<url> --user=<user> --password=<pass> --repository=<repo> > mybuildname_release.json
-conan art:build-info create create_debug.json mybuildname_debug 1 --url=<url> --user=<user> --password=<pass> --repository=<repo> > mybuildname_debug.json
+conan art:build-info create create_release.json mybuildname_release 1 <repo> --url=<url> --user=<user> --password=<pass> --with-dependencies > mybuildname_release.json
+conan art:build-info create create_debug.json mybuildname_debug 1 <repo> --url=<url> --user=<user> --password=<pass> --with-dependencies > mybuildname_debug.json
 ```
 
 You have to set the properties for the uploaded artifacts so they are linked to the BuildInfo in Artifactory:
 
 ```
-conan art:property build-info-add mybuildname_release.json <url> <repo> --user=<user> --password=<pass>
-conan art:property build-info-add mybuildname_debug.json <url> <repo> --user=<user> --password=<pass>
+conan art:property build-info-add mybuildname_release.json <url> --user=<user> --password=<pass>
+conan art:property build-info-add mybuildname_debug.json <url> --user=<user> --password=<pass>
 ```
 
 Finally, you can upload the BuildInfo's

--- a/extensions/commands/art/cmd_build_info.py
+++ b/extensions/commands/art/cmd_build_info.py
@@ -428,7 +428,7 @@ def build_info_create(conan_api: ConanAPI, parser, subparser, *args):
         data = json.load(f)
 
     bi = BuildInfo(data, args.build_name, args.build_number, args.repository, 
-                   dependencies=args.with_dependencies, url=args.url, user=args.user, password=args.password,
+                   with_dependencies=args.with_dependencies, url=args.url, user=args.user, password=args.password,
                    apikey=args.apikey)
 
     cli_out_write(bi.create())

--- a/extensions/commands/art/cmd_build_info.py
+++ b/extensions/commands/art/cmd_build_info.py
@@ -185,7 +185,7 @@ def unique_requires(transitive_reqs):
 class BuildInfo:
 
     def __init__(self, graph, name, number, repository, with_dependencies=False, 
-                 url=None, user=None, password=None, apikey=None, modules=None):
+                 url=None, user=None, password=None, apikey=None):
         self._graph = graph
         self._name = name
         self._number = number

--- a/extensions/commands/art/cmd_build_info.py
+++ b/extensions/commands/art/cmd_build_info.py
@@ -179,16 +179,18 @@ def unique_requires(transitive_reqs):
 
 class BuildInfo:
 
-    def __init__(self, graph, name, number, repositories=None, url=None, user=None, password=None, apikey=None):
+    def __init__(self, graph, name, number, dependencies=False, repository=None, 
+                 url=None, user=None, password=None, apikey=None, modules=None):
         self._graph = graph
         self._name = name
         self._number = number
-        self._repositories = repositories
+        self._repository = repository
         self._url = url
         self._user = user
         self._password = password
         self._apikey = apikey
         self._cached_artifact_info = {}
+        self._dependencies = dependencies
 
     def get_artifacts(self, node, artifact_type, is_dependency=False):
         """
@@ -221,8 +223,9 @@ class BuildInfo:
                                          "sha256": sha256,
                                          "sha1": sha1,
                                          "md5": md5}
+
                         if not is_dependency:
-                            artifact_info.update({"name": file_name, "path": f'{remote_path}/{file_name}'})
+                            artifact_info.update({"name": file_name, "path": f'{self._repository}/{remote_path}/{file_name}'})
                         else:
                             ref = node.get("ref")
                             pkg = f":{node.get('package_id')}#{node.get('prev')}" if artifact_type == "package" else ""
@@ -232,47 +235,41 @@ class BuildInfo:
             return local_artifacts
 
         def _get_remote_artifacts():
-            assert self._url and self._repositories, "Missing information in the Conan local cache, " \
-                                                     "please provide the --url and --repository arguments " \
-                                                     "to retrieve the information from Artifactory."
+            assert self._url and self._repository, "Missing information in the Conan local cache, " \
+                                                   "please provide the --url and --repository arguments " \
+                                                   "to retrieve the information from Artifactory."
 
             remote_artifacts = []
 
-            for repository in self._repositories:
-                # change from the conan API to the correct API to get files info and ignore if
-                # this can lead to problems, probably is better to pass manually a list of URLs
-                for artifact in artifacts_names:
-                    request_url = f"{self._url}/api/storage/{repository}/{remote_path}/{artifact}"
-                    if not self._cached_artifact_info.get(request_url):
-                        checksums = None
-                        try:
-                            response = api_request("get", request_url, self._user, self._password, self._apikey)
-                            response_data = json.loads(response)
-                            checksums = response_data.get("checksums")
-                            self._cached_artifact_info[request_url] = checksums
-                        except Exception:
-                            pass
+            for artifact in artifacts_names:
+                request_url = f"{self._url}/api/storage/{self._repository}/{remote_path}/{artifact}"
+                if not self._cached_artifact_info.get(request_url):
+                    checksums = None
+                    try:
+                        response = api_request("get", request_url, self._user, self._password, self._apikey)
+                        response_data = json.loads(response)
+                        checksums = response_data.get("checksums")
+                        self._cached_artifact_info[request_url] = checksums
+                    except Exception:
+                        pass
+                else:
+                    checksums = self._cached_artifact_info.get(request_url)
+
+                if checksums:
+                    artifact_info = {"type": os.path.splitext(artifact)[1].lstrip('.'),
+                                     "sha256": checksums.get("sha256"),
+                                     "sha1": checksums.get("sha1"),
+                                     "md5": checksums.get("md5")}
+
+                    artifact_path = f'{self._repository}/{remote_path}/{artifact}'
+                    if not is_dependency:
+                        artifact_info.update({"name": artifact, "path": artifact_path})
                     else:
-                        checksums = self._cached_artifact_info.get(request_url)
+                        ref = node.get("ref")
+                        pkg = f":{node.get('package_id')}#{node.get('prev')}" if artifact_type == "package" else ""
+                        artifact_info.update({"id": f"{ref}{pkg}::{artifact}"})
 
-                    if checksums:
-                        artifact_info = {"type": os.path.splitext(artifact)[1].lstrip('.'),
-                                         "sha256": checksums.get("sha256"),
-                                         "sha1": checksums.get("sha1"),
-                                         "md5": checksums.get("md5")}
-
-                        if not is_dependency:
-                            artifact_info.update({"name": artifact, "path": f'{remote_path}/{artifact}'})
-                        else:
-                            ref = node.get("ref")
-                            pkg = f":{node.get('package_id')}#{node.get('prev')}" if artifact_type == "package" else ""
-                            artifact_info.update({"id": f"{ref}{pkg}::{artifact}"})
-
-                        remote_artifacts.append(artifact_info)
-                    else:
-                        break
-                if remote_artifacts:
-                    break
+                    remote_artifacts.append(artifact_info)
 
             return remote_artifacts
 
@@ -322,13 +319,14 @@ class BuildInfo:
                         "artifacts": self.get_artifacts(node, "recipe")
                     }
 
-                    all_dependencies = []
-                    for require_id in unique_reqs:
-                        deps_artifacts = self.get_artifacts(get_node_by_id(nodes, require_id), "recipe",
-                                                            is_dependency=True)
-                        all_dependencies.extend(deps_artifacts)
+                    if self._dependencies:
+                        all_dependencies = []
+                        for require_id in unique_reqs:
+                            deps_artifacts = self.get_artifacts(get_node_by_id(nodes, require_id), "recipe",
+                                                                is_dependency=True)
+                            all_dependencies.extend(deps_artifacts)
 
-                    module.update({"dependencies": all_dependencies})
+                        module.update({"dependencies": all_dependencies})
 
                     ret.append(module)
 
@@ -340,13 +338,14 @@ class BuildInfo:
                             "artifacts": self.get_artifacts(node, "package")
                         }
                         # get the dependencies and its artifacts
-                        all_dependencies = []
-                        for require_id in unique_reqs:
-                            deps_artifacts = self.get_artifacts(get_node_by_id(nodes, require_id), "package",
-                                                                is_dependency=True)
-                            all_dependencies.extend(deps_artifacts)
+                        if self._dependencies:
+                            all_dependencies = []
+                            for require_id in unique_reqs:
+                                deps_artifacts = self.get_artifacts(get_node_by_id(nodes, require_id), "package",
+                                                                    is_dependency=True)
+                                all_dependencies.extend(deps_artifacts)
 
-                        module.update({"dependencies": all_dependencies})
+                            module.update({"dependencies": all_dependencies})
 
                         ret.append(module)
 
@@ -387,22 +386,25 @@ def build_info_create(conan_api: ConanAPI, parser, subparser, *args):
                                          "This may be not necessary if all the information for the Conan "
                                          "artifacts is present in the local cache.")
 
-    subparser.add_argument("--repository", help="Repositories to look artifacts for."
+    subparser.add_argument("--repository", help="Repository to look artifacts for."
                                                 "This may be not necessary if all the information for the Conan "
-                                                "artifacts is present in the local cache."
-                           , action="append")
+                                                "artifacts is present in the local cache.")
 
     subparser.add_argument("--user", help="user name for the repository")
     subparser.add_argument("--password", help="password for the user name")
     subparser.add_argument("--apikey", help="apikey for the repository")
+
+    subparser.add_argument("--with-dependencies", help="Whether to add dependencies information or not. Default: false.",
+                           action='store_true', default=False)
 
     args = parser.parse_args(*args)
 
     with open(args.json, 'r') as f:
         data = json.load(f)
 
-    bi = BuildInfo(data, args.build_name, args.build_number, args.repository, args.url, args.user, args.password,
-                   args.apikey)
+    bi = BuildInfo(data, args.build_name, args.build_number, dependencies=args.with_dependencies,
+                   repository=args.repository, url=args.url, user=args.user, password=args.password,
+                   apikey=args.apikey)
 
     cli_out_write(bi.create())
 

--- a/extensions/commands/art/cmd_build_info.py
+++ b/extensions/commands/art/cmd_build_info.py
@@ -184,7 +184,7 @@ def unique_requires(transitive_reqs):
 
 class BuildInfo:
 
-    def __init__(self, graph, name, number, dependencies=False, repository=None, 
+    def __init__(self, graph, name, number, repository, with_dependencies=False, 
                  url=None, user=None, password=None, apikey=None, modules=None):
         self._graph = graph
         self._name = name
@@ -195,7 +195,7 @@ class BuildInfo:
         self._password = password
         self._apikey = apikey
         self._cached_artifact_info = {}
-        self._dependencies = dependencies
+        self._with_dependencies = with_dependencies
 
     def get_artifacts(self, node, artifact_type, is_dependency=False):
         """
@@ -324,7 +324,7 @@ class BuildInfo:
                         "artifacts": self.get_artifacts(node, "recipe")
                     }
 
-                    if self._dependencies:
+                    if self._with_dependencies:
                         all_dependencies = []
                         for require_id in unique_reqs:
                             deps_artifacts = self.get_artifacts(get_node_by_id(nodes, require_id), "recipe",
@@ -343,7 +343,7 @@ class BuildInfo:
                             "artifacts": self.get_artifacts(node, "package")
                         }
                         # get the dependencies and its artifacts
-                        if self._dependencies:
+                        if self._with_dependencies:
                             all_dependencies = []
                             for require_id in unique_reqs:
                                 deps_artifacts = self.get_artifacts(get_node_by_id(nodes, require_id), "package",
@@ -408,14 +408,12 @@ def build_info_create(conan_api: ConanAPI, parser, subparser, *args):
     subparser.add_argument("json", help="Conan generated JSON output file.")
     subparser.add_argument("build_name", help="Build name property for BuildInfo.")
     subparser.add_argument("build_number", help="Build number property for BuildInfo.")
+    subparser.add_argument("repository", help="Repository to look artifacts for.")
 
     subparser.add_argument("--url", help="Artifactory url, like: https://<address>/artifactory. "
                                          "This may be not necessary if all the information for the Conan "
                                          "artifacts is present in the local cache.")
 
-    subparser.add_argument("--repository", help="Repository to look artifacts for."
-                                                "This may be not necessary if all the information for the Conan "
-                                                "artifacts is present in the local cache.")
 
     subparser.add_argument("--user", help="user name for the repository")
     subparser.add_argument("--password", help="password for the user name")
@@ -429,8 +427,8 @@ def build_info_create(conan_api: ConanAPI, parser, subparser, *args):
     with open(args.json, 'r') as f:
         data = json.load(f)
 
-    bi = BuildInfo(data, args.build_name, args.build_number, dependencies=args.with_dependencies,
-                   repository=args.repository, url=args.url, user=args.user, password=args.password,
+    bi = BuildInfo(data, args.build_name, args.build_number, args.repository, 
+                   dependencies=args.with_dependencies, url=args.url, user=args.user, password=args.password,
                    apikey=args.apikey)
 
     cli_out_write(bi.create())

--- a/extensions/commands/art/cmd_build_info.py
+++ b/extensions/commands/art/cmd_build_info.py
@@ -586,7 +586,7 @@ def build_info_append(conan_api: ConanAPI, parser, subparser, *args):
                 if not any(d['id'] == module.get('id') for d in all_modules):
                     all_modules.append(module)
 
-    bi = BuildInfo(None, args.build_name, args.build_number)
+    bi = BuildInfo(None, args.build_name, args.build_number, None)
     bi_json = bi.header()
     bi_json.update({"modules": all_modules})
     cli_out_write(json.dumps(bi_json, indent=4))

--- a/extensions/commands/art/cmd_property.py
+++ b/extensions/commands/art/cmd_property.py
@@ -180,7 +180,6 @@ def property_build_info_add(conan_api: ConanAPI, parser, subparser, *args):
 
     subparser.add_argument("json", help="Build Info JSON.")
     subparser.add_argument("url", help="Artifactory url, like: https://<address>/artifactory")
-    subparser.add_argument("repository", help="Artifactory repository.")
 
     subparser.add_argument("--user", help="user name for the repository")
     subparser.add_argument("--password", help="password for the user name")
@@ -199,7 +198,7 @@ def property_build_info_add(conan_api: ConanAPI, parser, subparser, *args):
             artifact_properties = {}
             artifact_path = artifact.get('path')
             try:
-                request_url = f"{args.url}/api/storage/{args.repository}/{artifact_path}?properties"
+                request_url = f"{args.url}/api/storage/{artifact_path}?properties"
                 props_response = api_request("get", request_url, args.user, args.password, args.apikey)
                 artifact_properties = json.loads(props_response).get("properties")
             except:
@@ -216,6 +215,6 @@ def property_build_info_add(conan_api: ConanAPI, parser, subparser, *args):
                 artifact_properties["build.number"] = build_number
         
 
-            request_url = f"{args.url}/api/metadata/{args.repository}/{artifact_path}"
+            request_url = f"{args.url}/api/metadata/{artifact_path}"
             api_request("patch", request_url, args.user, args.password,
                         args.apikey, json_data=json.dumps({"props": artifact_properties}))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 
+
 def pytest_collection_modifyitems(items):
     for item in items:
         if "requires_credentials" in item.keywords:

--- a/tests/test_artifactory_commands.py
+++ b/tests/test_artifactory_commands.py
@@ -147,8 +147,8 @@ def test_build_info_create_deps():
 
     run("conan upload 'mypkg/1.0' -c -r extensions-stg")
 
-    run(f'conan art:build-info create create_release.json {build_name}_release {build_number} --url={os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}" --repository=extensions-stg > {build_name}_release.json')
-    run(f'conan art:build-info create create_debug.json {build_name}_debug {build_number} --url={os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}" --repository=extensions-stg > {build_name}_debug.json')
+    run(f'conan art:build-info create create_release.json {build_name}_release {build_number} extensions-stg --url={os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}" > {build_name}_release.json')
+    run(f'conan art:build-info create create_debug.json {build_name}_debug {build_number} extensions-stg --url={os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}" > {build_name}_debug.json')
 
     run(f'conan art:property build-info-add {build_name}_release.json {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
     run(f'conan art:property build-info-add {build_name}_debug.json {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')

--- a/tests/test_artifactory_commands.py
+++ b/tests/test_artifactory_commands.py
@@ -53,8 +53,8 @@ def test_build_info_create_no_deps():
 
     run("conan upload mypkg/1.0 -c -r extensions-stg")
 
-    run(f'conan art:build-info create create_release.json {build_name}_release {build_number} --repository=extensions-stg > {build_name}_release.json')
-    run(f'conan art:build-info create create_debug.json {build_name}_debug {build_number} --repository=extensions-stg > {build_name}_debug.json')
+    run(f'conan art:build-info create create_release.json {build_name}_release {build_number} extensions-stg > {build_name}_release.json')
+    run(f'conan art:build-info create create_debug.json {build_name}_debug {build_number} extensions-stg > {build_name}_debug.json')
 
     run(f'conan art:property build-info-add {build_name}_release.json {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
     run(f'conan art:property build-info-add {build_name}_debug.json {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
@@ -147,8 +147,8 @@ def test_build_info_create_deps():
 
     run("conan upload 'mypkg/1.0' -c -r extensions-stg")
 
-    run(f'conan art:build-info create create_release.json {build_name}_release {build_number} extensions-stg --url={os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}" > {build_name}_release.json')
-    run(f'conan art:build-info create create_debug.json {build_name}_debug {build_number} extensions-stg --url={os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}" > {build_name}_debug.json')
+    run(f'conan art:build-info create create_release.json {build_name}_release {build_number} extensions-stg --url={os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}" --with-dependencies > {build_name}_release.json')
+    run(f'conan art:build-info create create_debug.json {build_name}_debug {build_number} extensions-stg --url={os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}" --with-dependencies > {build_name}_debug.json')
 
     run(f'conan art:property build-info-add {build_name}_release.json {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
     run(f'conan art:property build-info-add {build_name}_debug.json {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
@@ -212,11 +212,11 @@ def test_fail_if_not_uploaded():
 
     run("conan create . --format json -tf='' > create.json")
 
-    out = run(f'conan art:build-info create create.json {build_name} {build_number}', error=True)
+    out = run(f'conan art:build-info create create.json {build_name} {build_number} extensions-stg', error=True)
 
     assert "Missing information in the Conan local cache, please provide " \
            "the --url and --repository arguments to retrieve the information from" in out
 
-    out = run(f'conan art:build-info create create.json {build_name} {build_number} --url={os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}" --repository=extensions-stg > {build_name}.json', error=True)
+    out = run(f'conan art:build-info create create.json {build_name} {build_number} extensions-stg --url={os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}" > {build_name}.json', error=True)
 
     assert "There are no artifacts for the mypkg/1.0#" in out


### PR DESCRIPTION
Some minor fixes + adding a command to create a release bundle: https://jfrog.com/blog/release-trusted-software-faster-our-new-release-lifecycle-management-beta-is-here/ (this is currently in Beta, so it does not work in the testing Artifactory)