### PR TITLE
Simplify art:build-info UX

### DIFF
--- a/extensions/commands/art/README.md
+++ b/extensions/commands/art/README.md
@@ -77,13 +77,6 @@ conan art:build-info create create_release.json mybuildname_release 1 <repo> --u
 conan art:build-info create create_debug.json mybuildname_debug 1 <repo> --url=<url> --user=<user> --password=<pass> --with-dependencies > mybuildname_debug.json
 ```
 
-You have to set the properties for the uploaded artifacts so they are linked to the BuildInfo in Artifactory:
-
-```
-conan art:property build-info-add mybuildname_release.json <url> --user=<user> --password=<pass>
-conan art:property build-info-add mybuildname_debug.json <url> --user=<user> --password=<pass>
-```
-
 Finally, you can upload the BuildInfo's
 
 ```
@@ -97,5 +90,4 @@ create a new aggregated BuildInfo that we also will upload and set properties to
 ```
 conan art:build-info append mybuildname_aggregated 1 --build-info=mybuildname_release.json --build-info=mybuildname_debug.json > mybuildname_aggregated.json
 conan art:build-info upload mybuildname_aggregated.json <url> --user=<user> --password="<pass>"
-conan art:property build-info-add mybuildname_aggregated.json <url> <repo> --user=<user> --password="<pass>"
 ```

--- a/extensions/commands/art/cmd_build_info.py
+++ b/extensions/commands/art/cmd_build_info.py
@@ -471,16 +471,8 @@ def build_info_upload(conan_api: ConanAPI, parser, subparser, *args):
             except:
                 pass
 
-            if artifact_properties.get("build.name") and build_name not in artifact_properties.get("build.name"):
-                artifact_properties["build.name"].append(build_name)
-            else:
-                artifact_properties["build.name"] = build_name
-
-            if artifact_properties.get("build.number") and build_number not in artifact_properties.get("build.number"):
-                artifact_properties["build.number"].append(build_number)
-            else:
-                artifact_properties["build.number"] = build_number
-        
+            artifact_properties.setdefault("build.name", []).append(build_name)
+            artifact_properties.setdefault("build.number", []).append(build_number)        
 
             request_url = f"{args.url}/api/metadata/{artifact_path}"
             api_request("patch", request_url, args.user, args.password,

--- a/extensions/commands/art/cmd_property.py
+++ b/extensions/commands/art/cmd_property.py
@@ -106,6 +106,9 @@ def property_add(conan_api: ConanAPI, parser, subparser, *args):
 
     args = parser.parse_args(*args)
 
+    if not args.property:
+        raise ConanException("Please, add at least one property with the --property argument.")
+
     # TODO: do we want to add properties to folders? it's slower but when
     # we set properties recursive the folders are also set, so setting also
     # for folders for consistency and check what to do
@@ -139,10 +142,7 @@ def property_add(conan_api: ConanAPI, parser, subparser, *args):
 
         for property in args.property:
             key, val = property.split('=')[0], property.split('=')[1]
-            if artifact_properties.get(key) and val not in artifact_properties.get(key):
-                artifact_properties[key].append(val)
-            else:
-                artifact_properties[key] = val
+            artifact_properties.setdefault(key, []).append(val)
 
         if artifact_properties:
             request_url = f"{args.url}/api/metadata/{args.repository}/{root_path}{uri}?&recursiveProperties=0"
@@ -162,6 +162,9 @@ def property_set(conan_api: ConanAPI, parser, subparser, *args):
                            action='store_false', help='Will not recursively set properties.')
     args = parser.parse_args(*args)
 
+    if not args.property:
+        raise ConanException("Please, add at least one property with the --property argument.")
+
     recursive = "1" if args.recursive else "0"
 
     json_data = json.dumps(
@@ -175,12 +178,17 @@ def property_set(conan_api: ConanAPI, parser, subparser, *args):
 @conan_subcommand()
 def property_build_info_add(conan_api: ConanAPI, parser, subparser, *args):
     """
-    Load a Build Info JSON and add the build.number and build.name properties to all the artifacts present in the JSON.
+    Load a Build Info JSON and add the build.number and build.name properties to all the artifacts present in the JSON. 
+    You can also add arbitrary properties with the --property argument.
     """
 
     subparser.add_argument("json", help="Build Info JSON.")
     subparser.add_argument("url", help="Artifactory url, like: https://<address>/artifactory")
 
+    subparser.add_argument("--property", action='append',
+                           help='Property to add, like --property="key1=value1" --property="key2=value2". \
+                                 If the property already exists, the values are appended.')
+ 
     subparser.add_argument("--user", help="user name for the repository")
     subparser.add_argument("--password", help="password for the user name")
     subparser.add_argument("--apikey", help="apikey for the repository")
@@ -204,16 +212,13 @@ def property_build_info_add(conan_api: ConanAPI, parser, subparser, *args):
             except:
                 pass
 
-            if artifact_properties.get("build.name") and build_name not in artifact_properties.get("build.name"):
-                artifact_properties["build.name"].append(build_name)
-            else:
-                artifact_properties["build.name"] = build_name
+            artifact_properties.setdefault("build.name", []).append(build_name)
+            artifact_properties.setdefault("build.number", []).append(build_number)
 
-            if artifact_properties.get("build.number") and build_number not in artifact_properties.get("build.number"):
-                artifact_properties["build.number"].append(build_number)
-            else:
-                artifact_properties["build.number"] = build_number
-        
+            if args.property:
+                for property in args.property:
+                    key, val = property.split('=')[0], property.split('=')[1]
+                    artifact_properties.setdefault(key, []).append(val)
 
             request_url = f"{args.url}/api/metadata/{artifact_path}"
             api_request("patch", request_url, args.user, args.password,

--- a/tests/test_artifactory_commands.py
+++ b/tests/test_artifactory_commands.py
@@ -56,9 +56,6 @@ def test_build_info_create_no_deps():
     run(f'conan art:build-info create create_release.json {build_name}_release {build_number} extensions-stg > {build_name}_release.json')
     run(f'conan art:build-info create create_debug.json {build_name}_debug {build_number} extensions-stg > {build_name}_debug.json')
 
-    run(f'conan art:property build-info-add {build_name}_release.json {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
-    run(f'conan art:property build-info-add {build_name}_debug.json {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
-
     run(f'conan art:build-info upload {build_name}_release.json {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
     run(f'conan art:build-info upload {build_name}_debug.json {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
 
@@ -67,7 +64,6 @@ def test_build_info_create_no_deps():
     # with the build info in Artifactory
     run(f'conan art:build-info append {build_name}_aggregated {build_number} --build-info={build_name}_release.json --build-info={build_name}_debug.json > {build_name}_aggregated.json')
     run(f'conan art:build-info upload {build_name}_aggregated.json {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
-    run(f'conan art:property build-info-add {build_name}_aggregated.json {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
 
     run(f'conan art:build-info get {build_name}_release {build_number} {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
     run(f'conan art:build-info get {build_name}_debug {build_number} {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
@@ -150,15 +146,11 @@ def test_build_info_create_deps():
     run(f'conan art:build-info create create_release.json {build_name}_release {build_number} extensions-stg --url={os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}" --with-dependencies > {build_name}_release.json')
     run(f'conan art:build-info create create_debug.json {build_name}_debug {build_number} extensions-stg --url={os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}" --with-dependencies > {build_name}_debug.json')
 
-    run(f'conan art:property build-info-add {build_name}_release.json {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
-    run(f'conan art:property build-info-add {build_name}_debug.json {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
-
     run(f'conan art:build-info upload {build_name}_release.json {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
     run(f'conan art:build-info upload {build_name}_debug.json {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
 
     run(f'conan art:build-info append {build_name}_aggregated {build_number} --build-info={build_name}_release.json --build-info={build_name}_debug.json > {build_name}_aggregated.json')
     run(f'conan art:build-info upload {build_name}_aggregated.json {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
-    run(f'conan art:property build-info-add {build_name}_aggregated.json {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
 
     run(f'conan art:build-info get {build_name}_release {build_number} {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
     run(f'conan art:build-info get {build_name}_debug {build_number} {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')


### PR DESCRIPTION
It was redundant to set the properties after or before uploading the BuildInfo, you can do that in just one step.
Maybe we could remove the build-info add command or it could serve to add arbitrary properties to artifacts present in a BuildInfo