### PR TITLE
Fix wrong name for art:property command

### DIFF
--- a/extensions/commands/art/README.md
+++ b/extensions/commands/art/README.md
@@ -6,7 +6,7 @@ These are commands to manage certain Artifactory features:
 
 - ``conan art:build-info``. Manages JFROG BuildInfo
 
-- ``conan art:build-info``. Manages artifacts properties in Artifactory
+- ``conan art:property``. Manages artifacts properties in Artifactory
 
 
 #### [conan art:build-info](cmd_build_info.py)


### PR DESCRIPTION
The readme listed `art:build-info` twice when the second line should have been `art:property`.