### PR TITLE
[fix] sbom: Add Conan as default component author

### DIFF
--- a/extensions/commands/sbom/cmd_cyclonedx.py
+++ b/extensions/commands/sbom/cmd_cyclonedx.py
@@ -111,7 +111,7 @@ def cyclonedx(conan_api: ConanAPI, parser, *args) -> 'Bom':
             component = Component(
                 type=package_type_to_component_type(node.conanfile.package_type),  # noqa
                 name=node.name or f'UNKNOWN.{id(node)}',
-                author=node.conanfile.author,
+                author=node.conanfile.author if node.conanfile.author else "Conan",
                 version=node.conanfile.version,
                 licenses=licenses(node.conanfile.license),
                 bom_ref=purl.to_string() if purl else None,


### PR DESCRIPTION
After #80 we realized that the conan-center-index recipes do not include the ``author`` attribute. So we thought having a default "Conan" author makes sense in this case.

cc/ @erik-moqvist 