### PR TITLE
[SBOM] Drop support for cyclonedx-python-lib v4

### DIFF
--- a/.github/workflows/test_conan_extensions.yml
+++ b/.github/workflows/test_conan_extensions.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -U pip
-        pip install pytest "cyclonedx-python-lib>=3.1.5,<5.0.0"
+        pip install pytest "cyclonedx-python-lib>=3.1.5,!=4.*,<6"
     - name: Install Conan latest
       run: |
         pip install conan

--- a/.github/workflows/test_conan_extensions.yml
+++ b/.github/workflows/test_conan_extensions.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -U pip
-        pip install pytest "cyclonedx-python-lib>=3.1.5,!=4.*,<6"
+        pip install pytest "cyclonedx-python-lib>=5.0.0,<6"
     - name: Install Conan latest
       run: |
         pip install conan

--- a/extensions/commands/sbom/README.md
+++ b/extensions/commands/sbom/README.md
@@ -12,7 +12,7 @@ The command requires the package `cyclonedx-python-lib`.
 You can install it via
 <!-- keep in sync with the error message that asks for requirements/dependencies in `cmd_cyclonedx.py` -->
 ```shellSession
-$ pip install 'cyclonedx-python-lib>=3.1.5,!=4.*,<6'
+$ pip install 'cyclonedx-python-lib>=5.0.0,<6'
 ```
 
 Usage:

--- a/extensions/commands/sbom/README.md
+++ b/extensions/commands/sbom/README.md
@@ -12,7 +12,7 @@ The command requires the package `cyclonedx-python-lib`.
 You can install it via
 <!-- keep in sync with the error message that asks for requirements/dependencies in `cmd_cyclonedx.py` -->
 ```shellSession
-$ pip install 'cyclonedx-python-lib>=3.1.5,<5.0.0'
+$ pip install 'cyclonedx-python-lib>=3.1.5,!=4.*,<6'
 ```
 
 Usage:

--- a/extensions/commands/sbom/cmd_cyclonedx.py
+++ b/extensions/commands/sbom/cmd_cyclonedx.py
@@ -2,7 +2,7 @@ from importlib import import_module
 from functools import partial
 import os.path
 import sys
-from typing import TYPE_CHECKING, Iterable, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, List, Optional, Set, Tuple, Union
 
 from conan.api.conan_api import ConanAPI
 from conan.api.output import cli_out_write
@@ -47,8 +47,7 @@ def cyclonedx(conan_api: ConanAPI, parser, *args) -> 'Bom':
 
     try:
         from cyclonedx.factory.license import LicenseFactory
-        from cyclonedx.model import (ExternalReference, ExternalReferenceType,
-                                     LicenseChoice, Tool, XsUri)
+        from cyclonedx.model import ExternalReference, ExternalReferenceType, Tool, XsUri
         from cyclonedx.model.bom import Bom
         from cyclonedx.model.component import Component, ComponentType
         from packageurl import PackageURL
@@ -58,24 +57,24 @@ def cyclonedx(conan_api: ConanAPI, parser, *args) -> 'Bom':
         # if loading dependencies is performed outside the actual conan-command in global/module scope.
         print('The sbom extension needs an additional package, please run:',
               # keep in synk with the instructions in `README.md`
-              "pip install 'cyclonedx-python-lib>=3.1.5,<5.0.0'",
+              "pip install 'cyclonedx-python-lib>=3.1.5,!=4.*,<6'",
               sep='\n', file=sys.stderr)
         sys.exit(1)
 
     if TYPE_CHECKING:
         from conans.client.graph.graph import Node
 
-    def cyclonedx_major_version_is_4() -> bool:
+    def cyclonedx_major_version_is_5() -> bool:
         try:
-            LicenseChoice(license=LicenseFactory().make_from_string("MIT"))
-            return True
-        except TypeError:  # argument in version 3 is named license_
+            from cyclonedx import __version__
+            return __version__[0] == "5"
+        except ImportError:
             return False
 
     def package_type_to_component_type(pt: str) -> ComponentType:
         return ComponentType.APPLICATION if pt == "application" else ComponentType.LIBRARY
 
-    def licenses(ls: Optional[Union[Tuple[str, ...], Set[str], List[str], str]]) -> Optional[Iterable[LicenseChoice]]:
+    def licenses(ls: Optional[Union[Tuple[str, ...], Set[str], List[str], str]]):
         """
         see https://cyclonedx.org/docs/1.4/json/#components_items_licenses
         """
@@ -83,9 +82,10 @@ def cyclonedx(conan_api: ConanAPI, parser, *args) -> 'Bom':
             return None
         if not isinstance(ls, (tuple, set, list)):
             ls = [ls]
-        if cyclonedx_major_version_is_4():
-            return [LicenseChoice(license=LicenseFactory().make_from_string(i)) for i in ls]  # noqa
+        if cyclonedx_major_version_is_5():
+            return [LicenseFactory().make_from_string(i) for i in ls]  # noqa
         else:
+            from cyclonedx.model import LicenseChoice  # without that, xml cannot be serialized
             return [LicenseChoice(license_=LicenseFactory().make_from_string(i)) for i in ls]
 
     def package_url(node: 'Node') -> Optional[PackageURL]:
@@ -107,7 +107,7 @@ def cyclonedx(conan_api: ConanAPI, parser, *args) -> 'Bom':
 
     def create_component(node: 'Node') -> Component:
         purl = package_url(node)
-        if cyclonedx_major_version_is_4():
+        if cyclonedx_major_version_is_5():
             component = Component(
                 type=package_type_to_component_type(node.conanfile.package_type),  # noqa
                 name=node.name or f'UNKNOWN.{id(node)}',
@@ -129,7 +129,7 @@ def cyclonedx(conan_api: ConanAPI, parser, *args) -> 'Bom':
                 purl=purl,
                 description=node.conanfile.description
             )
-        if node.conanfile.homepage and cyclonedx_major_version_is_4():  # bug in cyclonedx 3 enforces hashes
+        if node.conanfile.homepage and cyclonedx_major_version_is_5():  # bug in cyclonedx 3 enforces hashes
             component.external_references.add(ExternalReference(
                 type=ExternalReferenceType.WEBSITE,  # noqa
                 url=XsUri(node.conanfile.homepage),
@@ -137,8 +137,8 @@ def cyclonedx(conan_api: ConanAPI, parser, *args) -> 'Bom':
         return component
 
     def me_as_tool() -> Tool:
-        tool = Tool(name="conan extension recipe:create-sbom")
-        if cyclonedx_major_version_is_4():
+        tool = Tool(name="conan extension sbom:cyclonedx")
+        if cyclonedx_major_version_is_5():
             tool.external_references.add(ExternalReference(
                 type=ExternalReferenceType.WEBSITE,  # noqa
                 url=XsUri("https://github.com/conan-io/conan-extensions")))  # noqa
@@ -182,7 +182,7 @@ def cyclonedx(conan_api: ConanAPI, parser, *args) -> 'Bom':
     bom.metadata.tools.add(me_as_tool())
     for node in deps_graph.nodes[1:]:  # node 0 is the root
         bom.components.add(components[node])
-    if cyclonedx_major_version_is_4():
+    if cyclonedx_major_version_is_5():
         for dep in deps_graph.nodes:
             bom.register_dependency(components[dep], [components[dep_dep.dst] for dep_dep in dep.dependencies])  # noqa
     return bom

--- a/extensions/commands/sbom/cmd_cyclonedx.py
+++ b/extensions/commands/sbom/cmd_cyclonedx.py
@@ -62,7 +62,7 @@ def cyclonedx(conan_api: ConanAPI, parser, *args) -> 'Bom':
         # if loading dependencies is performed outside the actual conan-command in global/module scope.
         print('The sbom extension needs an additional package, please run:',
               # keep in synk with the instructions in `README.md`
-              "pip install 'cyclonedx-python-lib>=5.0.0,<6",
+              "pip install 'cyclonedx-python-lib>=5.0.0,<6'",
               sep='\n', file=sys.stderr)
         sys.exit(1)
 

--- a/extensions/commands/sbom/cmd_cyclonedx.py
+++ b/extensions/commands/sbom/cmd_cyclonedx.py
@@ -45,6 +45,10 @@ formatter["text"] = format_text
 def cyclonedx(conan_api: ConanAPI, parser, *args) -> 'Bom':
     """Create a CycloneDX Software Bill of Materials (SBOM)"""
 
+    if sys.version_info < (3, 8):
+        print('Python 3.8 or newer is required.')
+        sys.exit(1)
+
     try:
         from cyclonedx.factory.license import LicenseFactory
         from cyclonedx.model import ExternalReference, ExternalReferenceType, Tool, XsUri

--- a/extensions/commands/sbom/cmd_cyclonedx.py
+++ b/extensions/commands/sbom/cmd_cyclonedx.py
@@ -50,10 +50,11 @@ def cyclonedx(conan_api: ConanAPI, parser, *args) -> 'Bom':
         sys.exit(1)
 
     try:
-        from cyclonedx.factory.license import License, LicenseFactory
+        from cyclonedx.factory.license import LicenseFactory
         from cyclonedx.model import ExternalReference, ExternalReferenceType, Tool, XsUri
         from cyclonedx.model.bom import Bom
         from cyclonedx.model.component import Component, ComponentType
+        from cyclonedx.model.license import License
         from packageurl import PackageURL
     except ModuleNotFoundError:
         # Assert on RUNTIME of the actual conan-command, that all requirements exist.

--- a/tests/test_sbom_cyclonedx.py
+++ b/tests/test_sbom_cyclonedx.py
@@ -12,16 +12,6 @@ REQ_VER = "6.2.1"
 REQ_DEP = "m4"
 
 
-def cyclonedx_major_version_is_4() -> bool:
-    try:
-        from cyclonedx.factory.license import LicenseFactory
-        from cyclonedx.model import LicenseChoice
-        LicenseChoice(license=LicenseFactory().make_from_string("MIT"))
-        return True
-    except TypeError:  # argument in version 3 is named license_
-        return False
-
-
 @pytest.fixture(autouse=True)
 def conan_test():
     old_env = dict(os.environ)
@@ -53,35 +43,31 @@ def _test_generated_sbom_json(sbom, test_metadata_name, spec_version):
 
 
 def _test_generated_sbom_xml(sbom, test_metadata_name, spec_version):
-    def with_ns(key: str) -> str:
-        ns = "ns0:" if cyclonedx_major_version_is_4() else ""
-        return ns + key
-
-    schema = sbom.getAttribute("xmlns:ns0" if cyclonedx_major_version_is_4() else "xmlns")
+    schema = sbom.getAttribute("xmlns")
     assert "cyclonedx" in schema
     assert schema.split("/")[-1] == spec_version
 
     if spec_version not in ['1.1', '1.0']:
-        metadata = sbom.getElementsByTagName(with_ns("metadata"))
+        metadata = sbom.getElementsByTagName("metadata")
         assert metadata
-        component = metadata[0].getElementsByTagName(with_ns("component"))
+        component = metadata[0].getElementsByTagName("component")
         assert component
         if test_metadata_name:
-            assert component[0].getElementsByTagName(with_ns("name"))[0].firstChild.nodeValue == "TestPackage"
+            assert component[0].getElementsByTagName("name")[0].firstChild.nodeValue == "TestPackage"
 
-    components = sbom.getElementsByTagName(with_ns("components"))
+    components = sbom.getElementsByTagName("components")
     assert components
-    components = components[0].getElementsByTagName(with_ns("component"))
+    components = components[0].getElementsByTagName("component")
     assert components
     assert 1 == len([
         c for c in components if
-        c.getElementsByTagName(with_ns("name"))[0].firstChild.nodeValue == REQ_LIB
+        c.getElementsByTagName("name")[0].firstChild.nodeValue == REQ_LIB
         and
-        c.getElementsByTagName(with_ns("version"))[0].firstChild.nodeValue == REQ_VER
+        c.getElementsByTagName("version")[0].firstChild.nodeValue == REQ_VER
     ])
     assert 1 == len([
         c for c in components if
-        c.getElementsByTagName(with_ns("name"))[0].firstChild.nodeValue == REQ_DEP
+        c.getElementsByTagName("name")[0].firstChild.nodeValue == REQ_DEP
     ])
 
 


### PR DESCRIPTION
This PR drops support for cyclonedx-python-lib v4 as dependency track cannot parse the resulting XML. We now support only v5.

New XML was tested with dependency track v4.9.1 and it works now

fixes #88 