### PR TITLE
Fix for when args.path is not used

### DIFF
--- a/extensions/commands/cci/cmd_export_all_versions.py
+++ b/extensions/commands/cci/cmd_export_all_versions.py
@@ -101,7 +101,7 @@ def export_all_versions(conan_api, parser, *args):
         folders_to_export = item[recipe_name][0]['folders'] if isinstance(item, dict) else None
         out.verbose(f"Processing recipe '{recipe_name}'")
 
-        recipe_folder = os.path.join(args.path, recipe_name)
+        recipe_folder = os.path.join(args.path, recipe_name) if args.path is not None else os.path.join(f"{os.getcwd()}/recipes", recipe_name)
         if not os.path.isdir(recipe_folder):
             raise ConanException(f"Invalid user input: '{recipe_name}' does not exist or is not a dir")
 

--- a/tests/test_export_all_versions.py
+++ b/tests/test_export_all_versions.py
@@ -68,7 +68,7 @@ def test_list_arg():
     save("list.yml", list_yml)
 
     run("conan cci:export-all-versions -l list.yml")
-    assert len(os.listdir(os.path.join(os.environ.get("CONAN_HOME"), "p"))) == 4
+    assert len(os.listdir(os.path.join(os.environ.get("CONAN_HOME"), "p"))) == 6
 
 def test_name_arg():
     run("conan cci:export-all-versions -n pkga")

--- a/tests/test_export_all_versions.py
+++ b/tests/test_export_all_versions.py
@@ -22,8 +22,8 @@ def conan_test():
         os.environ.clear()
         os.environ.update(old_env)
 
-
-def test_convert_txt():
+@pytest.fixture(autouse=True)
+def create_dummy_recipe_and_file_tree():
     repo = os.path.join(os.path.dirname(__file__), "..")
     run(f"conan config install {repo}")
     run("conan --help")
@@ -53,6 +53,24 @@ def test_convert_txt():
     os.mkdir("recipes/pkgb/all")
     save("recipes/pkgb/all/conanfile.py", conanfile % "pkgb")
 
+def test_path_arg():
     run("conan cci:export-all-versions -p recipes")
 
     assert len(os.listdir(os.path.join(os.environ.get("CONAN_HOME"), "p"))) == 6
+
+def test_list_arg():
+    list_yml = """
+        recipes:
+          - pkga
+          - pkgb
+    """
+
+    save("list.yml", list_yml)
+
+    run("conan cci:export-all-versions -l list.yml")
+    assert len(os.listdir(os.path.join(os.environ.get("CONAN_HOME"), "p"))) == 6
+
+def test_name_arg():
+    run("conan cci:export-all-version -n pkga")
+    assert len(os.listdir(os.path.join(os.environ.get("CONAN_HOME"), "p"))) == 3
+

--- a/tests/test_export_all_versions.py
+++ b/tests/test_export_all_versions.py
@@ -68,9 +68,9 @@ def test_list_arg():
     save("list.yml", list_yml)
 
     run("conan cci:export-all-versions -l list.yml")
-    assert len(os.listdir(os.path.join(os.environ.get("CONAN_HOME"), "p"))) == 6
+    assert len(os.listdir(os.path.join(os.environ.get("CONAN_HOME"), "p"))) == 4
 
 def test_name_arg():
-    run("conan cci:export-all-version -n pkga")
-    assert len(os.listdir(os.path.join(os.environ.get("CONAN_HOME"), "p"))) == 3
+    run("conan cci:export-all-versions -n pkga")
+    assert len(os.listdir(os.path.join(os.environ.get("CONAN_HOME"), "p"))) == 4
 


### PR DESCRIPTION
With the current implementation of the CCI `export_all_versions` command you can either pass a config file, a path or a name.

There's currently a bug when not using a path argument. When either the config file or a name is parsed `args.path` is still used to locate the recipes directory. However because no path has been parsed as an arg it is undefined (i.e None).

This PR adds a check condition to check if `args.path` is undefined and if it is, it uses the `cwd/recipes` path, to comply with the expectation that this script should run from the root of a CCI file tree. When a path is indeed requested and `args.path` is not undefined, its value is used.