### PR TITLE
Fix broken tests in PR's because of missing requires_credentials

### DIFF
--- a/tests/test_artifactory_commands.py
+++ b/tests/test_artifactory_commands.py
@@ -312,6 +312,7 @@ def test_server_add_error():
     assert f"Server 'server1' ({server_url}) already exist." in out_add
 
 
+@pytest.mark.requires_credentials
 def test_server_remove_error():
     """
     Test server remove errors when there is no server with the provided name
@@ -321,6 +322,7 @@ def test_server_remove_error():
     assert "Server 'server1' does not exist." in out
 
 
+@pytest.mark.requires_credentials
 def test_server_list_empty():
     """
     Test server list output when no servers are configured


### PR DESCRIPTION
Probably the cause this fails: https://github.com/conan-io/conan-extensions/pull/106