### PR TITLE
Fix `re.search()` failed to match in Chinese environment

### DIFF
--- a/extensions/hooks/_hook_copy_pdbs_to_package.py
+++ b/extensions/hooks/_hook_copy_pdbs_to_package.py
@@ -31,7 +31,7 @@ def post_package(conanfile):
         dumpbin_output = StringIO()
         conanfile.run(rf'"{dumpbin_path}" /PDBPATH {dll_path}', stdout=dumpbin_output)
         dumpbin = str(dumpbin_output.getvalue())
-        pdb_path = re.search(r"'.*\.pdb'", dumpbin)
+        pdb_path = re.search(r"[“'\"].*\.pdb[”'\"]", dumpbin)
         if pdb_path:
             pdb_path = pdb_path.group()[1:-1]
             # Copy the corresponding pdb file from the build to the package folder


### PR DESCRIPTION
In a Chinese environment the dumpbin string looks like this: 
~~~shell
Microsoft (R) COFF/PE Dumper Version 14.29.30154.0
Copyright (C) Microsoft Corporation.  All rights reserved.


Dump of file C:\Users\NiceBlueChai\.conan2\p\b\qt3a51a5d711623\p\bin\archdatadir\qml\QtTest\qmltestplugin.dll

File Type: DLL
 找到 PDB 文件(在“C:\Users\NiceBlueChai\.conan2\p\b\qt3a51a5d711623\b\build_folder\qtdeclarative\qml\QtTest\qmltestplugin.pdb”中)

  Summary

        2000 .data
        1000 .pdata
        1000 .qtmetad
        5000 .rdata
        1000 .reloc
        1000 .rsrc
        7000 .text
~~~