### PR TITLE
[art:build-info] feature: Add --add-cached-nodes flag to allow recollection of non-built packages

### DIFF
--- a/tests/test_artifactory_commands.py
+++ b/tests/test_artifactory_commands.py
@@ -1,4 +1,5 @@
 import os
+import json
 import tempfile
 
 from tools import run, save


### PR DESCRIPTION
based on the work done at #78 but dropping the python requires related changes from #75

closes #78
closes #100 
closes #124