### PR TITLE
Set supplier instead of author to Conan

### DIFF
--- a/extensions/commands/sbom/cmd_cyclonedx.py
+++ b/extensions/commands/sbom/cmd_cyclonedx.py
@@ -51,7 +51,7 @@ def cyclonedx(conan_api: ConanAPI, parser, *args) -> 'Bom':
 
     try:
         from cyclonedx.factory.license import LicenseFactory
-        from cyclonedx.model import ExternalReference, ExternalReferenceType, Tool, XsUri
+        from cyclonedx.model import ExternalReference, ExternalReferenceType, OrganizationalEntity, Tool, XsUri
         from cyclonedx.model.bom import Bom
         from cyclonedx.model.component import Component, ComponentType
         from cyclonedx.model.license import License
@@ -102,7 +102,8 @@ def cyclonedx(conan_api: ConanAPI, parser, *args) -> 'Bom':
         component = Component(
             type=package_type_to_component_type(node.conanfile.package_type),
             name=node.name or f'UNKNOWN.{id(node)}',
-            author=node.conanfile.author if node.conanfile.author else "Conan",
+            author=node.conanfile.author if node.conanfile.author else None,
+            supplier=OrganizationalEntity(name="Conan"),
             version=node.conanfile.version,
             licenses=licenses(node.conanfile.license),
             bom_ref=purl.to_string() if purl else None,


### PR DESCRIPTION
We would like to use Conan's SBOM generation in our organization but there are still a few obstacles. For one, our organization requires the _supplier_ to be set (while the _author_ is optional). 

This seems to match the description about "minimum elements" in https://www.ntia.doc.gov/files/ntia/publications/sbom_minimum_elements_report.pdf, which requires the "Supplier Name" for components and the "Author of SBOM Data". I believe the original interpretation in the original PR (#80) was mistaken.

From the [CycloneDX spec](https://github.com/CycloneDX/specification/blob/1.6/schema/bom-1.4.schema.json):
* _component.supplier_: The organization that supplied the component. The supplier may often be the manufacturer, but may also be a distributor or repackager.
* _component.author_: The person(s) or organization(s) that authored the component.

Both fields are optional from a spec point of view, which is why I set the _author_ to `None`. However, in our interpretation, the _author_ is the developer of the component, while the _supplier_ is Conan/Conan Center in this case.

Please let me know what you think in case you disagree.