### PR TITLE
[fix] In licenses deployer, ignore user and channel in filenames

### DIFF
--- a/extensions/deployers/licenses.py
+++ b/extensions/deployers/licenses.py
@@ -28,11 +28,11 @@ def deploy(graph, output_folder, **kwargs):
         for f in os.listdir(search_dir):
             src = os.path.join(search_dir)
             # Let's kep the name and version so we know which belongs to whats
-            dst = os.path.join(tmp_dir, str(d.ref))
+            dst = os.path.join(tmp_dir, str(d.ref.name), str(d.ref.version))
             out.debug(src)
             out.debug(dst)
             copy(conanfile, f, src, dst) # Using the conan help because it make's parent folders
-            files.append(os.path.join(str(d.ref),f))
+            files.append(os.path.join(str(d.ref.name), str(d.ref.version), f))
 
     out.trace(files)
     with zipfile.ZipFile(os.path.join(output_folder, 'licenses.zip'), 'w') as licenses_zip:


### PR DESCRIPTION
The case where some Conan packages might have a _user/channel_ in their name wasn't handled correctly. The _user_ component was appended to the _version_. This fix explicitly uses only _name_ and _version_ for determining the filename.

Folder structure before:
```
cxxopts/                                                                                                                                                                                       
cxxopts/3.1.1/                                                                                                                                                                                 
dtoa/                                                                                                                                                                                          
dtoa/1.0.4@comp/                                                                                                                                                                               
dtoa/1.0.4@comp/stable/                                                                                                                                                                        
fast-cdr/                                                                                                                                                                                      
fast-cdr/2.1.0/                                                                                                                                                                                
```

Folder structure after:
```
cxxopts/
cxxopts/3.1.1/
dtoa/
dtoa/1.0.4/
fast-cdr/
fast-cdr/2.1.0/
```