### PR TITLE
Revert "Fix: Fix CI for artifactory tests colliding in parallel run"

### DIFF
--- a/.github/workflows/test_conan_extensions.yml
+++ b/.github/workflows/test_conan_extensions.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -U pip
-        pip install pytest pytest-order "cyclonedx-python-lib>=5.0.0,<6"
+        pip install pytest "cyclonedx-python-lib>=5.0.0,<6"
     - name: Install Conan latest
       run: |
         pip install conan
@@ -44,7 +44,7 @@ jobs:
     - name: Install dependencies and Conan latest
       run: |
         pip install -U pip
-        pip install pytest pytest-order conan
+        pip install pytest conan
     - name: Run Windows-specific tests - Conan latest / Python 3.8
       run: |
         pytest -v -m win32 tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-markers =
-    requires_credentials: mark tests that require credentials for Artifactory
-    win32: mark tests that should be run only on a Windows machine

--- a/tests/test_artifactory_commands.py
+++ b/tests/test_artifactory_commands.py
@@ -57,7 +57,6 @@ def conan_test():
 
 
 @pytest.mark.requires_credentials
-@pytest.mark.order(1)
 def test_build_info_create_no_deps():
 
     build_name = "mybuildinfo"
@@ -122,7 +121,6 @@ def test_build_info_create_no_deps():
 
 
 @pytest.mark.requires_credentials
-@pytest.mark.order(2)
 def test_build_info_create_with_build_url():
 
     build_name = "mybuildinfo"
@@ -143,7 +141,6 @@ def test_build_info_create_with_build_url():
 
 
 @pytest.mark.requires_credentials
-@pytest.mark.order(3)
 def test_build_info_create_deps():
     #         +-------+
     #         | libc  |
@@ -236,7 +233,6 @@ def test_build_info_create_deps():
 
 
 @pytest.mark.requires_credentials
-@pytest.mark.order(4)
 def test_build_info_create_from_cached_deps():
     # Make sure artifactory repos are empty before starting the test
     run("conan remove mypkg* -c -r extensions-stg")
@@ -271,7 +267,6 @@ def test_build_info_create_from_cached_deps():
 
 
 @pytest.mark.requires_credentials
-@pytest.mark.order(5)
 def test_fail_if_not_uploaded():
     """
     In order to create the Build Info we need the hashes of the artifacts that are uploaded
@@ -292,7 +287,6 @@ def test_fail_if_not_uploaded():
 
 
 @pytest.mark.requires_credentials
-@pytest.mark.order(5)
 def test_build_info_project():
     """
     Test that build info is correctly manages using a project in Artifactory
@@ -335,7 +329,6 @@ def test_build_info_project():
 
 
 @pytest.mark.requires_credentials
-@pytest.mark.order(7)
 def test_build_info_dependency_different_repo():
     """
     Test that build info is correctly generated for a package with dependencies in a different repo in Artifactory
@@ -389,7 +382,6 @@ def test_build_info_dependency_different_repo():
 
 
 @pytest.mark.requires_credentials
-@pytest.mark.order(8)
 def test_server_complete():
     """
     Test server add, list, remove commands
@@ -419,7 +411,6 @@ def test_server_complete():
 
 
 @pytest.mark.requires_credentials
-@pytest.mark.order(9)
 def test_server_add_error():
     """
     Test server add error when adding a server with same name
@@ -443,7 +434,6 @@ def test_server_add_error():
 
 
 @pytest.mark.requires_credentials
-@pytest.mark.order(10)
 def test_server_remove_error():
     """
     Test server remove errors when there is no server with the provided name
@@ -454,7 +444,6 @@ def test_server_remove_error():
 
 
 @pytest.mark.requires_credentials
-@pytest.mark.order(11)
 def test_server_list_empty():
     """
     Test server list output when no servers are configured
@@ -465,7 +454,6 @@ def test_server_list_empty():
 
 
 @pytest.mark.requires_credentials
-@pytest.mark.order(12)
 def test_add_server_token():
     """
     Test server add with token


### PR DESCRIPTION
Reverts conan-io/conan-extensions#151

Pytest should be already running test sequentially.
We are reverting these changes to test this situation further.