### PR TITLE
Fix empty buildinfo when using conan export-package

### DIFF
--- a/extensions/commands/art/cmd_build_info.py
+++ b/extensions/commands/art/cmd_build_info.py
@@ -389,7 +389,7 @@ def build_info_create(conan_api: ConanAPI, parser, subparser, *args):
     data = load_json(args.json)
 
     # remove the 'conanfile' node
-    if data["graph"]["nodes"]["0"]["ref"] == "conanfile":
+    if not data["graph"]["nodes"]["0"]["prev"]:
         data["graph"]["nodes"].pop("0")
     bi = _BuildInfo(data, args.build_name, args.build_number, args.repository,
                     build_url=args.build_url,

--- a/extensions/commands/art/cmd_build_info.py
+++ b/extensions/commands/art/cmd_build_info.py
@@ -389,7 +389,8 @@ def build_info_create(conan_api: ConanAPI, parser, subparser, *args):
     data = load_json(args.json)
 
     # remove the 'conanfile' node
-    data["graph"]["nodes"].pop("0")
+    if data["graph"]["nodes"]["0"]["ref"] == "conanfile":
+        data["graph"]["nodes"].pop("0")
     bi = _BuildInfo(data, args.build_name, args.build_number, args.repository,
                     build_url=args.build_url,
                     with_dependencies=args.with_dependencies,

--- a/extensions/commands/art/cmd_build_info.py
+++ b/extensions/commands/art/cmd_build_info.py
@@ -389,6 +389,7 @@ def build_info_create(conan_api: ConanAPI, parser, subparser, *args):
     data = load_json(args.json)
 
     # remove the 'conanfile' node
+    # remove only if package revision == null that means that the node has no binaries
     if not data["graph"]["nodes"]["0"]["prev"]:
         data["graph"]["nodes"].pop("0")
     bi = _BuildInfo(data, args.build_name, args.build_number, args.repository,

--- a/tests/test_artifactory_commands.py
+++ b/tests/test_artifactory_commands.py
@@ -489,5 +489,3 @@ def test_build_info_create_exppkg():
     out = run(f'conan art:build-info create create_release.json {build_name}_release {build_number} --server=artifactory extensions-stg')
     build_info = json.loads(out)
     assert len(build_info['modules']) == 2
-
-    run('conan remove mypkg_ext* -c -r extensions-stg')

--- a/tests/test_artifactory_commands.py
+++ b/tests/test_artifactory_commands.py
@@ -154,8 +154,7 @@ def test_build_info_create_exppkg():
     # Create release packages & build info and upload them
     run("conan export-pkg . --format json -s build_type=Release > create_release.json")
     run("conan upload mypkg_ext/1.0 -c -r extensions-stg")
-    out = run(
-        f'conan art:build-info create create_release.json {build_name}_release {build_number} --url="{os.getenv("ART_URL")}" --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}" extensions-stg')
+    out = run(f'conan art:build-info create create_release.json {build_name}_release {build_number} --server=artifactory extensions-stg')
     build_info = json.loads(out)
     assert len(build_info['modules']) == 2
 

--- a/tests/test_artifactory_commands.py
+++ b/tests/test_artifactory_commands.py
@@ -141,27 +141,6 @@ def test_build_info_create_with_build_url():
 
 
 @pytest.mark.requires_credentials
-def test_build_info_create_exppkg():
-    build_name = "mybuildinfo"
-    build_number = "1"
-
-    # Configure Artifactory server and credentials
-    run(f'conan art:server add artifactory {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
-
-    # Generate recipe to work with
-    run("conan new basic -d name=mypkg_ext -d version=1.0 --force")
-
-    # Create release packages & build info and upload them
-    run("conan export-pkg . --format json -s build_type=Release > create_release.json")
-    run("conan upload mypkg_ext/1.0 -c -r extensions-stg")
-    out = run(f'conan art:build-info create create_release.json {build_name}_release {build_number} --server=artifactory extensions-stg')
-    build_info = json.loads(out)
-    assert len(build_info['modules']) == 2
-
-    # Finally clean the artifactory repo (Deleting the build infos does not remove pacakges from repos)
-    run('conan remove mypkg_ext* -c -r extensions-prod')
-
-@pytest.mark.requires_credentials
 def test_build_info_create_deps():
     #         +-------+
     #         | libc  |
@@ -491,3 +470,24 @@ def test_add_server_token():
     out_add = run(f'conan art:server add server1 {server_url} --user="{server_user}" --token="{token}"')
 
     assert f"Server 'server1' ({server_url}) added successfully" in out_add
+
+
+@pytest.mark.requires_credentials
+def test_build_info_create_exppkg():
+    build_name = "mybuildinfo"
+    build_number = "1"
+
+    # Configure Artifactory server and credentials
+    run(f'conan art:server add artifactory {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
+
+    # Generate recipe to work with
+    run("conan new basic -d name=mypkg_ext -d version=1.0 --force")
+
+    # Create release packages & build info and upload them
+    run("conan export-pkg . --format json -s build_type=Release > create_release.json")
+    run("conan upload mypkg_ext/1.0 -c -r extensions-stg")
+    out = run(f'conan art:build-info create create_release.json {build_name}_release {build_number} --server=artifactory extensions-stg')
+    build_info = json.loads(out)
+    assert len(build_info['modules']) == 2
+
+    run('conan remove mypkg_ext* -c -r extensions-stg')

--- a/tests/test_artifactory_commands.py
+++ b/tests/test_artifactory_commands.py
@@ -141,6 +141,28 @@ def test_build_info_create_with_build_url():
 
 
 @pytest.mark.requires_credentials
+def test_build_info_create_exppkg():
+    build_name = "mybuildinfo"
+    build_number = "1"
+
+    # Configure Artifactory server and credentials
+    run(f'conan art:server add artifactory {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
+
+    # Generate recipe to work with
+    run("conan new basic -d name=mypkg_ext -d version=1.0 --force")
+
+    # Create release packages & build info and upload them
+    run("conan export-pkg . --format json -s build_type=Release > create_release.json")
+    run("conan upload mypkg_ext/1.0 -c -r extensions-stg")
+    out = run(
+        f'conan art:build-info create create_release.json {build_name}_release {build_number} --url="{os.getenv("ART_URL")}" --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}" extensions-stg')
+    build_info = json.loads(out)
+    assert len(build_info['modules']) == 2
+
+    # Finally clean the artifactory repo (Deleting the build infos does not remove pacakges from repos)
+    run('conan remove mypkg_ext* -c -r extensions-prod')
+
+@pytest.mark.requires_credentials
 def test_build_info_create_deps():
     #         +-------+
     #         | libc  |


### PR DESCRIPTION
Copy of this one: https://github.com/conan-io/conan-extensions/pull/155
As commented by @getrostt in the original PR:

>When building a conan package using `conan export-pkg`, the resulting build-info when running `conan art:build-info >create` is empty. This is caused by an unconditional removal of the 1st graph node in the resulting json file.

To run tests with credentials