### PR TITLE
Add a --no-build-requires command line option to the sbom:cyclonedx extension command

### DIFF
--- a/extensions/commands/sbom/cmd_cyclonedx.py
+++ b/extensions/commands/sbom/cmd_cyclonedx.py
@@ -154,7 +154,7 @@ def cyclonedx(conan_api: ConanAPI, parser, *args) -> 'Bom':
                                                          remotes, args.update)
     # endregion COPY
 
-    def filter_context(node): return not args.no_build_requires or node.context != CONTEXT_BUILD
+    def filter_context(n): return not args.no_build_requires or n.context != CONTEXT_BUILD
 
     components = {node: create_component(node) for node in deps_graph.nodes if filter_context(node)}
     bom = Bom()


### PR DESCRIPTION
sbom:cyclonedx --no-build-requires will omit build requirements from the generated SBOM, i.e. keeping only dependencies that are in the host context.

closes #158