### PR TITLE
Simplify license deployer, support nested folders

### DIFF
--- a/extensions/deployers/licenses.py
+++ b/extensions/deployers/licenses.py
@@ -1,42 +1,29 @@
 import os
 import zipfile
 from conan.api.output import ConanOutput
-from conan.tools.files import copy, rmdir
+
 
 # USE **KWARGS to be robust against changes
 def deploy(graph, output_folder, **kwargs):
     out = ConanOutput("deployer(licenses)")
     conanfile = graph.root.conanfile
-    files = []
-    
-    # Cleanup before we start :)
-    tmp_dir = os.path.join(output_folder, "licenses")
-    if os.path.exists(tmp_dir):
-        rmdir(conanfile, tmp_dir)
 
     # For each dep
-    for r, d in conanfile.dependencies.items():
-        if d.package_folder is None:
-            continue
-        
-        # Look for a licenses folder
-        search_dir = os.path.join(d.package_folder, "licenses") # This is the CCI convention
-        if not os.path.isdir(search_dir):
-            continue
-
-        # Grab all the files and copy them to a temp dir (this is what we will zip)
-        for f in os.listdir(search_dir):
-            src = os.path.join(search_dir)
-            # Let's kep the name and version so we know which belongs to whats
-            dst = os.path.join(tmp_dir, str(d.ref.name), str(d.ref.version))
-            out.debug(src)
-            out.debug(dst)
-            copy(conanfile, f, src, dst) # Using the conan help because it make's parent folders
-            files.append(os.path.join(str(d.ref.name), str(d.ref.version), f))
-
-    out.trace(files)
     with zipfile.ZipFile(os.path.join(output_folder, 'licenses.zip'), 'w') as licenses_zip:
-        for f in files:
-            file = os.path.join(tmp_dir, f)
-            licenses_zip.write(file, arcname=f, compress_type=zipfile.ZIP_DEFLATED)
-            os.remove(file) # Delete all the files we copied! This is so the source control stays clean
+        for r, d in conanfile.dependencies.items():
+            if d.package_folder is None:
+                continue
+
+            # Look for a licenses folder
+            search_dir = os.path.join(d.package_folder, "licenses")  # This is the CCI convention
+            if not os.path.isdir(search_dir):
+                continue
+
+            # Grab all the files and write them in the zipfile
+            for root, _, files in os.walk(search_dir):
+                # Let's keep the name and version so we know which belongs to what
+                for file in files:
+                    src = os.path.join(root, file)
+                    dst = os.path.join(str(d.ref.name), str(d.ref.version), os.path.relpath(root, search_dir), file)
+                    out.debug(f"Copying {src} to {dst}")
+                    licenses_zip.write(src, arcname=dst, compress_type=zipfile.ZIP_DEFLATED)

--- a/tests/test_deploy_licenses.py
+++ b/tests/test_deploy_licenses.py
@@ -23,6 +23,7 @@ def conan_test():
         os.environ.clear()
         os.environ.update(old_env)
 
+
 def test_deploy_licenses():
     repo = os.path.join(os.path.dirname(__file__), "..")
     run(f"conan config install {repo}")
@@ -38,6 +39,8 @@ def test_deploy_licenses():
 
             def package(self):
                 save(self, os.path.join(self.package_folder, "licenses", "hello.txt"), "example licenses")
+                save(self, os.path.join(self.package_folder, "licenses", "extra", "license2.txt"), "example licenses")
+                save(self, os.path.join(self.package_folder, "licenses", "extra", "tooling", "license.txt"), "example licenses")
         """)
     
     # Let's build a application to bundle
@@ -48,3 +51,5 @@ def test_deploy_licenses():
     run("conan install --requires hello/0.1 --deployer=licenses")
     shutil.unpack_archive("licenses.zip", "zip_contents")
     assert os.path.isfile(os.path.join("zip_contents", "hello", "0.1", "hello.txt"))
+    assert os.path.isfile(os.path.join("zip_contents", "hello", "0.1", "extra", "license2.txt"))
+    assert os.path.isfile(os.path.join("zip_contents", "hello", "0.1", "extra", "tooling", "license.txt"))


### PR DESCRIPTION
This PR simplifies the license depolyer, while also adding support for nested license folders

It fixes a bug where the folder structure would be left in the output folder, but which didn't contain the licenses themselves. We now directly zip the licenseses

Closes #161 

cc @lia-viam