### PR TITLE
Fix art:build-info create for recipe-only dependencies

### DIFF
--- a/extensions/commands/art/cmd_build_info.py
+++ b/extensions/commands/art/cmd_build_info.py
@@ -254,12 +254,17 @@ class _BuildInfo:
                         "artifacts": self.get_artifacts(node, "recipe")
                     }
 
+                    def is_node_type(node, node_type):
+                        assert node_type in ["recipe", "package"]
+                        return (node_type == "package" and node.get("package_folder")) or (node_type == "recipe" and node.get("recipe_folder"))
+
                     if self._with_dependencies:
                         all_dependencies = []
                         for require_id in transitive_dependencies:
-                            deps_artifacts = self.get_artifacts(nodes.get(require_id), "recipe",
-                                                                is_dependency=True)
-                            all_dependencies.extend(deps_artifacts)
+                            if is_node_type(nodes.get(require_id), "recipe"):
+                                deps_artifacts = self.get_artifacts(nodes.get(require_id), "recipe",
+                                                                    is_dependency=True)
+                                all_dependencies.extend(deps_artifacts)
 
                         module.update({"dependencies": all_dependencies})
 
@@ -276,9 +281,10 @@ class _BuildInfo:
                         if self._with_dependencies:
                             all_dependencies = []
                             for require_id in transitive_dependencies:
-                                deps_artifacts = self.get_artifacts(nodes.get(require_id), "package",
-                                                                    is_dependency=True)
-                                all_dependencies.extend(deps_artifacts)
+                                if is_node_type(nodes.get(require_id), "package"):
+                                    deps_artifacts = self.get_artifacts(nodes.get(require_id), "package",
+                                                                        is_dependency=True)
+                                    all_dependencies.extend(deps_artifacts)
 
                             module.update({"dependencies": all_dependencies})
 


### PR DESCRIPTION
We've been seeing the same issue in our project as in https://github.com/conan-io/conan-extensions/issues/166
I think the problem is that some dependencies are recipe-only, like this one for example:
<details>
  <summary>Click to expand JSON</summary>

```JSON
{
   "ref":"meson/1.3.2#d1125ba555ec1a94f165a3412fdf7f88",
   "id":"7",
   "recipe":"Cache",
   "package_id":"da39a3ee5e6b4b0d3255bfef95601890afd80709",
   "prev":"3ba677cf44c95996f4f326c668f92f00",
   "rrev":"d1125ba555ec1a94f165a3412fdf7f88",
   "rrev_timestamp":1717762194.047,
   "prev_timestamp":1718105046.468,
   "remote":"artifactory",
   "binary_remote":"artifactory",
   "build_id":null,
   "binary":"Skip",
   "invalid_build":false,
   "info_invalid":null,
   "name":"meson",
   "user":null,
   "channel":null,
   "url":"https://github.com/conan-io/conan-center-index",
   "license":"Apache-2.0",
   "author":null,
   "description":"Meson is a project to create the best possible next-generation build system",
   "homepage":"https://github.com/mesonbuild/meson",
   "build_policy":null,
   "upload_policy":null,
   "revision_mode":"hash",
   "provides":null,
   "deprecated":null,
   "win_bash":null,
   "win_bash_run":null,
   "default_options":null,
   "options_description":null,
   "version":"1.3.2",
   "topics":[
      "meson",
      "mesonbuild",
      "build-system"
   ],
   "package_type":"application",
   "languages":[
      
   ],
   "settings":{
      
   },
   "options":{
      
   },
   "options_definitions":{
      
   },
   "generators":[
      
   ],
   "python_requires":null,
   "system_requires":{
      
   },
   "recipe_folder":"C:\\Users\\dnoveczky\\.conan2\\p\\meson664925a500958\\e",
   "source_folder":null,
   "build_folder":null,
   "generators_folder":null,
   "package_folder":null,
   "cpp_info":{
      "root":{
         "includedirs":[
            "include"
         ],
         "srcdirs":null,
         "libdirs":[
            "lib"
         ],
         "resdirs":null,
         "bindirs":[
            "bin"
         ],
         "builddirs":null,
         "frameworkdirs":null,
         "system_libs":null,
         "frameworks":null,
         "libs":null,
         "defines":null,
         "cflags":null,
         "cxxflags":null,
         "sharedlinkflags":null,
         "exelinkflags":null,
         "objects":null,
         "sysroot":null,
         "requires":null,
         "properties":null
      }
   },
   "conf_info":{
      
   },
   "label":"meson/1.3.2",
   "info":{
      
   },
   "vendor":false,
   "dependencies":{
      "8":{
         "ref":"ninja/1.11.1",
         "run":true,
         "libs":false,
         "skip":false,
         "test":false,
         "force":false,
         "direct":true,
         "build":false,
         "transitive_headers":null,
         "transitive_libs":null,
         "headers":false,
         "package_id_mode":null,
         "visible":true
      }
   },
   "context":"build",
   "test":false
}
```
</details>

Notice how the `recipe_folder` field has a value but `package_folder` doesn't.
`get_artifacts()` was called on it twice, [here](https://github.com/conan-io/conan-extensions/blob/main/extensions/commands/art/cmd_build_info.py#L260) and [here](https://github.com/conan-io/conan-extensions/blob/main/extensions/commands/art/cmd_build_info.py#L279). The first call succeeded since the node had a `recipe_folder` value, but the second failed because it doesn't have a `package_folder` value.
I added a check to see if these values exist so that `get_artifacts()` only gets called when it's expected to return meaningful values.