### PR TITLE
Fix: Zip Deployer crashes when subfolder exist

### DIFF
--- a/extensions/deployers/runtime_zip_deploy.py
+++ b/extensions/deployers/runtime_zip_deploy.py
@@ -3,6 +3,23 @@ import shutil
 import zipfile
 
 
+def _get_files_from_folder(search_dir, output_folder):
+    # recusively copy all .dlls and .exes from the search_dir to the output_folder
+    if not os.path.isdir(search_dir):
+        return []
+    files = []
+    for f in os.listdir(search_dir):
+        src = os.path.join(search_dir, f)
+        if f.endswith(".dll") or f.endswith(".exe") or f.endswith(".dylib") or os.access(src, os.X_OK):
+            if os.path.isfile(src):
+                dst = os.path.join(output_folder, f)
+                shutil.copy2(src, dst)
+                files.append(dst)
+            else:
+                files += _get_files_from_folder(src, output_folder)
+    return files
+
+
 # USE **KWARGS to be robust against changes
 def deploy(graph, output_folder, **kwargs):
     conanfile = graph.root.conanfile
@@ -14,16 +31,9 @@ def deploy(graph, output_folder, **kwargs):
         search_dirs = (d.cpp_info.bindirs or []) + (d.cpp_info.libdirs or [])
         for dir in search_dirs:
             search_dir = os.path.join(d.package_folder, dir)
-            if not os.path.isdir(search_dir):
-                continue
-            for f in os.listdir(search_dir):
-                src = os.path.join(search_dir, f)
-                if f.endswith(".dll") or f.endswith(".exe") or f.endswith(".dylib") or os.access(src, os.X_OK):
-                    dst = os.path.join(output_folder, f)
-                    shutil.copy2(src, dst)
-                    files.append(dst)
+            files += _get_files_from_folder(search_dir, output_folder)
 
-    with zipfile.ZipFile(os.path.join(output_folder, 'runtime.zip'), 'w') as myzip:
+    with zipfile.ZipFile(os.path.join(output_folder, "runtime.zip"), "w") as myzip:
         for f in files:
             myzip.write(f, os.path.basename(f), compress_type=zipfile.ZIP_DEFLATED)
             os.remove(f)

--- a/tests/test_deploy_runtime_zip.py
+++ b/tests/test_deploy_runtime_zip.py
@@ -10,7 +10,7 @@ from tools import run
 @pytest.fixture(autouse=True)
 def conan_test():
     old_env = dict(os.environ)
-    env_vars = {"CONAN_HOME": tempfile.mkdtemp(suffix='conans')} 
+    env_vars = {"CONAN_HOME": tempfile.mkdtemp(suffix="conans")}
     os.environ.update(env_vars)
     current = tempfile.mkdtemp(suffix="conans")
     cwd = os.getcwd()
@@ -22,11 +22,12 @@ def conan_test():
         os.environ.clear()
         os.environ.update(old_env)
 
+
 def test_deploy_runtime_zip():
     repo = os.path.join(os.path.dirname(__file__), "..")
     run(f"conan config install {repo}")
     run("conan --help")
-    
+
     # Let's build a application to bundle
     run("conan new cmake_exe --define name=hello --define version=0.1")
     run("conan profile detect")
@@ -37,3 +38,28 @@ def test_deploy_runtime_zip():
     dir_list = os.listdir("zip_contents")
     assert len(dir_list) == 1
     assert isinstance(dir_list[0], str) and dir_list[0].startswith("hello")
+
+
+def test_deploy_runtime_zip_with_folder():
+    repo = os.path.join(os.path.dirname(__file__), "..")
+    run(f"conan config install {repo}")
+    run("conan --help")
+
+    # Let's build a application to bundle
+    run("conan new cmake_exe --define name=hello --define version=0.1")
+    # add additional folder for test case
+    with open("CMakeLists.txt", "a") as f:
+        f.write("""\n\nadd_executable(hello2 src/hello.cpp src/main.cpp)
+install(TARGETS hello2 DESTINATION "."
+        RUNTIME DESTINATION bin/folder
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        )""")
+    run("conan profile detect")
+    run("conan create .")
+
+    run("conan install --requires hello/0.1 --deployer=runtime_zip_deploy")
+    shutil.unpack_archive("runtime.zip", "zip_contents")
+    dir_list = os.listdir("zip_contents")
+    assert len(dir_list) == 2
+    assert all(isinstance(dir_list_elem, str) and dir_list_elem.startswith("hello") for dir_list_elem in dir_list)


### PR DESCRIPTION
Right now, the zip deployer crashes with an exception when a subfolder exists inside bin or lib. This can easily be checked with

```
conan install --requires=boost/1.85.0 --deployer=runtime_zip_deploy`
```

The change add sone unittest with a minimal project that creates a folder inside `bin` to ensure that it does not crash like the current version does.