### PR TITLE
Add bundle-promote command

### DIFF
--- a/demos/build-info/README.md
+++ b/demos/build-info/README.md
@@ -99,6 +99,9 @@ conan art:build-info upload debug_build.json --server=myartifactory
 
 conan art:build-info bundle-create aggregated_bundle 1.0 test_key_pair --server=myartifactory --build-info=debug_build,1 --build-info=release_build,1
 
+# Promote the bundle to PROD environment
+conan art:build-info bundle-promote aggregated_bundle 1.0 PROD --server=myartifactory
+
 # You can delete the bundle 
 conan art:build-info bundle-delete aggregated_bundle 1.0 --server=myartifactory
 ```

--- a/extensions/commands/art/cmd_build_info.py
+++ b/extensions/commands/art/cmd_build_info.py
@@ -720,8 +720,9 @@ def build_info_bundle_promote(conan_api: ConanAPI, parser, subparser, *args):
     assert_server_or_url_user_password(args)
     url, user, password = get_url_user_password(args)
     
+    # remove artifactory from the url because we have to use the lifecycle API
     parsed_url = urlparse(url)
-    base_url = f"{parsed_url.scheme}://{parsed_url.hostname}:8082"
+    base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
     
     request_url = f"{base_url}/lifecycle/api/v2/promotion/records/{args.bundle_name}/{args.bundle_version}?async={args.async_param}"
     if args.project:

--- a/tests/test_artifactory_commands.py
+++ b/tests/test_artifactory_commands.py
@@ -225,7 +225,11 @@ def test_build_info_create_deps():
     # run(f'conan install --requires=mypkg/1.0')
 
     run(f'conan art:build-info bundle-create full_bundle 1.0 --server="artifactory" test_key_pair --build-info={build_name}_release,{build_number} --build-info={build_name}_debug,{build_number}')
-    run(f'conan art:build-info bundle-delete full_bundle 1.0 --server="artifactory"')
+
+    # FIXME: configure testing artifactory so we can run the promotion
+    # run('conan art:build-info bundle-promote full_bundle 1.0 PROD --server=artifactory')
+
+    run('conan art:build-info bundle-delete full_bundle 1.0 --server="artifactory"')
 
     # Remove build-infos to clean artifactory
     run(f'conan art:build-info delete {build_name}_release --build-number={build_number} --server="artifactory" --delete-all --delete-artifacts')


### PR DESCRIPTION
To promote bundles between environments. API Docs: https://jfrog.com/help/r/jfrog-rest-apis/promote-release-bundle-v2-version

Can't test on CI yet until we configure the environments.
