### PR TITLE
Make hook_copy_pdbs_to_package search dumpbin.exe in all products.

### DIFF
--- a/extensions/hooks/_hook_copy_pdbs_to_package.py
+++ b/extensions/hooks/_hook_copy_pdbs_to_package.py
@@ -20,7 +20,7 @@ def post_package(conanfile):
     try:
         program_files = os.environ.get("ProgramFiles(x86)") or os.environ.get("ProgramFiles")  # fallback for 32-bit windows
         conanfile.run(
-            rf'"{program_files}\Microsoft Visual Studio\Installer\vswhere.exe" -find "**\dumpbin.exe" -format json',
+            rf'"{program_files}\Microsoft Visual Studio\Installer\vswhere.exe" -find "**\dumpbin.exe" -products * -format json',
             stdout=output, scope="")
         match = re.search(r'\[(.*?)\]', str(output.getvalue()), re.DOTALL)
         dumpbin_path = json.loads(f'[{match.group(1)}]')[0]


### PR DESCRIPTION

This PR add the "-products *" option to the vswhere command in the hook_copy_pdbs_to_package hook in order to find the BuildTools dumpbin.exe.

It fix the issue #186 .

regards,