### PR TITLE
Add support for artifacts from multiple repos in Build Info

### DIFF
--- a/.github/workflows/test_conan_extensions.yml
+++ b/.github/workflows/test_conan_extensions.yml
@@ -64,6 +64,11 @@ jobs:
             -H "Content-Type: application/json" \
             -d '{ "rclass": "local", "packageType": "conan", "repoLayoutRef": "conan-default", "description": "Local Conan repository for staging" }'
 
+        curl -u "${{ secrets.ARTIFACTORY_USER }}:${{ secrets.ARTIFACTORY_USER_PASSWORD }}" --output /dev/null \
+            -X PUT "http://localhost:8081/artifactory/api/repositories/third-party \
+            -H "Content-Type: application/json" \
+            -d '{ "rclass": "local", "packageType": "conan", "repoLayoutRef": "conan-default", "description": "Local Conan repository for third-party testing" }'
+
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/test_conan_extensions.yml
+++ b/.github/workflows/test_conan_extensions.yml
@@ -65,7 +65,7 @@ jobs:
             -d '{ "rclass": "local", "packageType": "conan", "repoLayoutRef": "conan-default", "description": "Local Conan repository for staging" }'
 
         curl -u "${{ secrets.ARTIFACTORY_USER }}:${{ secrets.ARTIFACTORY_USER_PASSWORD }}" --output /dev/null \
-            -X PUT "http://localhost:8081/artifactory/api/repositories/third-party \
+            -X PUT "http://localhost:8081/artifactory/api/repositories/third-party" \
             -H "Content-Type: application/json" \
             -d '{ "rclass": "local", "packageType": "conan", "repoLayoutRef": "conan-default", "description": "Local Conan repository for third-party testing" }'
 

--- a/extensions/commands/art/cmd_build_info.py
+++ b/extensions/commands/art/cmd_build_info.py
@@ -129,6 +129,8 @@ class _BuildInfo:
         self._add_cached_deps = add_cached_deps
 
     def _get_origin_repo(self, node):
+        if not self._repositories:
+            raise ConanException("No repositories were provided to search for artifacts.")
 
         # If only one repository is specified, all artifacts must belong to it.
         if len(self._repositories) == 1:

--- a/extensions/commands/art/cmd_build_info.py
+++ b/extensions/commands/art/cmd_build_info.py
@@ -130,6 +130,10 @@ class _BuildInfo:
         self._add_cached_deps = add_cached_deps
 
     def _get_origin_repo(self, node):
+        # If no URL is provided, we cannot check remotes, so we assume the main repository.
+        if not self._url:
+            return self._repository
+
         # For artifacts built in this run, use always the main repository.
         if node.get("binary") == "Build":
             return self._repository

--- a/extensions/commands/art/cmd_build_info.py
+++ b/extensions/commands/art/cmd_build_info.py
@@ -113,13 +113,13 @@ def _get_requested_by(nodes, node_id, artifact_type):
 
 class _BuildInfo:
 
-    def __init__(self, graph, name, number, repository, search_repositories, build_url=None, with_dependencies=False,
+    def __init__(self, graph, name, number, repository, search_repositories=None, build_url=None, with_dependencies=False,
                  add_cached_deps=False, url=None, user=None, password=None):
         self._graph = graph
         self._name = name
         self._number = number
         self._repository = repository
-        self._search_repositories = search_repositories
+        self._search_repositories = search_repositories or [repository]
         self._url = url
         self._user = user
         self._build_url = build_url

--- a/extensions/commands/art/cmd_build_info.py
+++ b/extensions/commands/art/cmd_build_info.py
@@ -130,16 +130,15 @@ class _BuildInfo:
 
     def _get_origin_repo(self, node):
 
-        # if we did not specify more than one then we have all our artifacts hosted
-        # in the same repo
+        # If only one repository is specified, all artifacts must belong to it.
         if len(self._repositories) == 1:
             return self._repositories[0]
 
-        # If no URL is provided, we cannot check remotes, so we assume the main repository.
+        # If multiple repositories are given, a URL is required to check the artifact's origin.
         if not self._url:
             raise ConanException(
-                "Missing Artifactory URL. To be able to match artifacts with source repository "
-                "please provide '--url' or '--server' arguments to retrieve the information from Artifactory."
+                "When multiple repositories are specified, Artifactory url is required to "
+                "determine the origin of dependencies. Please provide '--url' or '--server'."
             )
 
         ref_str = node.get("ref")
@@ -158,9 +157,10 @@ class _BuildInfo:
             except NotFoundException:
                 continue
 
-        # If not found in any remote repository, raise error
+        # If not found in any remote repository, raise an error.
         raise ConanException(
-            f"Unable to find {ref_str} in any of the passed repositories. Please check..."
+            f"Could not determine the origin of the reference '{ref_str}'. "
+            f"The package was not found in any of the specified repositories: {', '.join(self._repositories)}"
         )
 
 

--- a/tests/test_artifactory_commands.py
+++ b/tests/test_artifactory_commands.py
@@ -416,7 +416,7 @@ def test_build_info_dependency_different_repo():
 def test_build_info_dependency_from_extra_repo():
     """
     Tests that the build-info correctly attributes a dependency's path
-    to the --extra-repository it was found in.
+    to the repository it was found in.
     """
     #         +-------+
     #         | dep   | (from third-party repo)
@@ -449,8 +449,8 @@ def test_build_info_dependency_from_extra_repo():
     # Create the build-info, specifying the extra repository
     build_name = "build_with_extra_repo"
     build_number = "1"
-    run(f'conan art:build-info create create.json {build_name} {build_number} extensions-stg '
-        f'--extra-repository third-party --with-dependencies --add-cached-deps '
+    run(f'conan art:build-info create create.json {build_name} {build_number} extensions-stg third-party'
+        f'--with-dependencies --add-cached-deps '
         f'--server=artifactory > {build_name}.json')
 
     # Verify the generated build-info

--- a/tests/test_artifactory_commands.py
+++ b/tests/test_artifactory_commands.py
@@ -431,6 +431,9 @@ def test_build_info_dependency_from_extra_repo():
     run("conan remove mypkg* -c -r extensions-stg")
     run("conan remove mypkg* -c -r third-party")
 
+    # Configure Artifactory server and credentials
+    run(f'conan art:server add artifactory {os.getenv("ART_URL")} --user="{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" --password="{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
+
     # Create dependency and upload it to the 'third-party' repo
     run("conan new cmake_lib -d name=dep -d version=1.0 --force")
     run("conan create .")

--- a/tests/test_artifactory_commands.py
+++ b/tests/test_artifactory_commands.py
@@ -38,20 +38,26 @@ def conan_test():
     if "extensions-prod" not in out:
         run(f'conan remote add extensions-prod {os.getenv("ART_URL")}/api/conan/extensions-prod')
 
+    if "third-party" not in out:
+        run(f'conan remote add third-party {os.getenv("ART_URL")}/api/conan/third-party')
+
     run(f'conan remote login extensions-stg "{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_STG")}" -p "{os.getenv("CONAN_PASSWORD_EXTENSIONS_STG")}"')
     run(f'conan remote login extensions-prod "{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_PROD")}" -p "{os.getenv("CONAN_PASSWORD_EXTENSIONS_PROD")}"')
+    run(f'conan remote login third-party "{os.getenv("CONAN_LOGIN_USERNAME_EXTENSIONS_PROD")}" -p "{os.getenv("CONAN_PASSWORD_EXTENSIONS_PROD")}"')
     # Install extension commands (this repo)
     repo = os.path.join(os.path.dirname(__file__), "..")
     run(f"conan config install {repo}")
 
     run("conan remove '*' -c -r extensions-stg")
     run("conan remove '*' -c -r extensions-prod")
+    run("conan remove '*' -c -r third-party")
 
     try:
         yield
     finally:
         run("conan remove '*' -c -r extensions-stg")
         run("conan remove '*' -c -r extensions-prod")
+        run("conan remove '*' -c -r third-party")
         os.chdir(cwd)
         os.environ.clear()
         os.environ.update(old_env)

--- a/tests/test_artifactory_commands.py
+++ b/tests/test_artifactory_commands.py
@@ -426,6 +426,11 @@ def test_build_info_dependency_from_extra_repo():
     #          | pkg | (from extensions-stg repo)
     #          +-----+
 
+
+    # Make sure artifactory repos are empty before starting the test
+    run("conan remove mypkg* -c -r extensions-stg")
+    run("conan remove mypkg* -c -r third-party")
+
     # Create dependency and upload it to the 'third-party' repo
     run("conan new cmake_lib -d name=dep -d version=1.0 --force")
     run("conan create .")

--- a/tests/test_artifactory_commands.py
+++ b/tests/test_artifactory_commands.py
@@ -449,7 +449,7 @@ def test_build_info_dependency_from_extra_repo():
     # Create the build-info, specifying the extra repository
     build_name = "build_with_extra_repo"
     build_number = "1"
-    run(f'conan art:build-info create create.json {build_name} {build_number} extensions-stg third-party'
+    run(f'conan art:build-info create create.json {build_name} {build_number} extensions-stg third-party '
         f'--with-dependencies --add-cached-deps '
         f'--server=artifactory > {build_name}.json')
 


### PR DESCRIPTION
Closes: https://github.com/conan-io/conan-extensions/issues/198

- multiple positional `repository` arguments: to pass one or more extra repos to the command for it to look for dependencies there. It will use these repos to look for each dependency's `conanmanifest.txt` to make a link artifact <-> repo
- If you add more than one repository you have to upload the artifacts involved in the build before creating the build info, otherwise if not found it will fail
- For only one repo the behaviour is the same it was before these changes
