### PR TITLE
Fix art:promote needing overwrite permissions

### DIFF
--- a/extensions/commands/art/cmd_promote.py
+++ b/extensions/commands/art/cmd_promote.py
@@ -71,10 +71,12 @@ def _promote_path(url, user, password, origin, destination, path, continue_on_40
 def _promote_package_prev(url, user, password, origin, destination, pref_with_prev):
     revision_path = _get_path_from_pref(pref_with_prev)
     # Manually promote the files, Artifactory will take care of the timestamp
-    for file in ("conan_package.tgz", "conaninfo.txt", "conanmanifest.txt"):
+    for file, continue_on_error in (("conan_package.tgz", True),
+                                    ("conaninfo.txt", False),
+                                    ("conanmanifest.txt", False)):
         _promote_path(url, user, password, origin, destination,
                       f"{revision_path}/{file}",
-                      continue_on_400=True)
+                      continue_on_400=continue_on_error)
 
 
 @conan_command(group="Artifactory")


### PR DESCRIPTION
This also fixes a bug where every package revision would be promoted if none was specified. It now correctly throws an error requesting the user to specify which revisions should be promoted.

The same behaviour was applied to the recipe revision check: Where it previously skipped the recipe if no revision was given, it now errors out so the user is aware that no promotion is taking place.

TODO:
* Tests are still needed to check for this
* The old version fallback of

```py
try:
    from conan.api.model import RecipeReference, PkgReference
except:
    from conans.model.recipe_ref import RecipeReference
    from conans.model.package_ref import PkgReference
```

was removed, but we might want to bring that back