### PR TITLE
Added --status option for art:build-info promote

### DIFF
--- a/extensions/commands/art/cmd_build_info.py
+++ b/extensions/commands/art/cmd_build_info.py
@@ -509,9 +509,13 @@ def build_info_promote(conan_api: ConanAPI, parser, subparser, *args):
 
     subparser.add_argument("--dependencies", help="Whether to copy the build's dependencies or not. Default: false.",
                            action='store_true', default=False)
+    subparser.add_argument("--status", help="The new status of the build. Default: ''")
     subparser.add_argument("--comment", help="An optional comment describing the reason for promotion. Default: ''")
 
     args = parser.parse_args(*args)
+    if args.comment and not args.status:
+        ConanOutput().warning("A comment was provided without a --status. The comment will not be tracked.")
+
     assert_server_or_url_user_password(args)
 
     url, user, password = get_url_user_password(args)
@@ -523,6 +527,7 @@ def build_info_promote(conan_api: ConanAPI, parser, subparser, *args):
         # otherwise you can end up deleting recipe artifacts that other packages use
         "copy": "true",
         "dependencies": "true" if args.dependencies else "false",
+        "status": args.status,
         "comment": args.comment
     }
 


### PR DESCRIPTION
Following [`build-promotion`](https://jfrog.com/help/r/jfrog-rest-apis/build-promotion) documentation, we can see that effectively, if you create a `build-info` with a `comment` but no `status` is added, the promotion history won't be tracked.


#### Demo

Following this steps, 
```sh
$ conan new cmake_exe -d name="myapp" -d version=1.0
$ conan create . --format json > graph.json
$ conan art:build-info create graph.json mybuildname 1 dev --server myartifactory > mybuildname.json
$ conan art:build-info upload mybuildname.json --server myartifactory
$ conan art:build-info promote mybuildname 1 dev prod --server myartifactory --comment "All good"
```
will result in:
![empty-comment](https://github.com/user-attachments/assets/b025bc21-d176-4ccf-8110-a39dbad260a7)

But, with this new option, 
```sh
$ conan art:build-info promote mybuildname 1 dev prod --server myartifactory --comment "All good" --status "My Status"
```
![with-comment](https://github.com/user-attachments/assets/9d17cf2d-20b1-4e15-8de1-c0367c1b8aef)



Fix https://github.com/conan-io/conan-extensions/issues/216