### PR TITLE
fix(sbom): fixing typo in PURL description

### DIFF
--- a/extensions/commands/sbom/cmd_cyclonedx.py
+++ b/extensions/commands/sbom/cmd_cyclonedx.py
@@ -91,7 +91,7 @@ def cyclonedx(conan_api: ConanAPI, parser, *args) -> 'Bom':
             version=node.conanfile.version,
             qualifiers={
                 "prev": node.prev,
-                "rref": node.ref.revision if node.ref else None,
+                "rrev": node.ref.revision if node.ref else None,
                 "user": node.conanfile.user,
                 "channel": node.conanfile.channel,
                 "repository_url": node.remote.url if node.remote else None


### PR DESCRIPTION
The recipe rev identifier in the created PURL was misspelled as "rref" instead of "rrev".  For reference this is the correct spelling according to the PURL specification: https://github.com/package-url/purl-spec/blob/f319c8ebe478a9c410d47aa56ed9a42720422562/docs/types/definitions/conan-definition.md?plain=1#L45 